### PR TITLE
Copy and Deepcopy are identity ops because keys are immutable

### DIFF
--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -187,12 +187,17 @@ class OpaqueKey(object):
         return self.NAMESPACE_SEPARATOR.join([self.CANONICAL_NAMESPACE, self._to_string()])  # pylint: disable=no-member
 
     def __copy__(self):
-        return self.replace()
+        """
+        Because it's immutable, return itself
+        """
+        return self
 
     def __deepcopy__(self, memo):
-        return self.replace(**{
-            key: deepcopy(getattr(self, key), memo) for key in self.KEY_FIELDS  # pylint: disable=no-member
-        })
+        """
+        Because it's immutable, return itself
+        """
+        memo[id(self)] = self
+        return self
 
     def __setstate__(self, state_dict):
         # used by pickle to set fields on an unpickled object

--- a/opaque_keys/tests/test_opaque_keys.py
+++ b/opaque_keys/tests/test_opaque_keys.py
@@ -155,12 +155,12 @@ class KeyTests(TestCase):
         deep = copy.deepcopy(original)
 
         self.assertEquals(original, copied)
-        self.assertNotEquals(id(original), id(copied))
+        self.assertEquals(id(original), id(copied))
         self.assertEquals(id(original.value), id(copied.value))
 
         self.assertEquals(original, deep)
-        self.assertNotEquals(id(original), id(deep))
-        self.assertNotEquals(id(original.value), id(deep.value))
+        self.assertEquals(id(original), id(deep))
+        self.assertEquals(id(original.value), id(deep.value))
 
         self.assertEquals(copy.deepcopy([original]), [original])
 


### PR DESCRIPTION
@cpennington please review
