### PR TITLE
Add sub-package opaque_keys.edx to setup.py's package list.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     version="0.1",
     packages=[
         "opaque_keys",
+        "opaque_keys.edx",
     ],
     install_requires=[
         "stevedore"


### PR DESCRIPTION
To fix error happening on edx-platform: `Error: Could not import settings 'lms.envs.aws' (Is it on sys.path?): No module named opaque_keys.edx.keys`

@mulby, @e0d 
