### PR TITLE
Adding deprecation value to replace function

### DIFF
--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -257,10 +257,12 @@ class OpaqueKey(object):
     def replace(self, **kwargs):
         """
         Return: a new :class:`OpaqueKey` with ``KEY_FIELDS`` specified in ``kwargs`` replaced
-            their corresponding values.
+            their corresponding values. Deprecation value is also preserved.
         """
         existing_values = {key: getattr(self, key) for key in self.KEY_FIELDS}  # pylint: disable=no-member
         existing_values.update(kwargs)
+        if 'deprecated' not in existing_values:
+            existing_values['deprecated'] = self.deprecated
         return type(self)(**existing_values)
 
     def __setattr__(self, name, value):

--- a/opaque_keys/tests/test_opaque_keys.py
+++ b/opaque_keys/tests/test_opaque_keys.py
@@ -198,6 +198,22 @@ class KeyTests(TestCase):
         self.assertEquals(HexKey(10), hex10)
         self.assertEquals(HexKey(11), hex11)
 
+    def test_replace_deprecated_property(self):
+        deprecated_hex10 = HexKey(10, deprecated=True)
+        deprecated_hex11 = deprecated_hex10.replace(value=11)
+        not_deprecated_hex10 = deprecated_hex10.replace(deprecated=False)
+        deprecated_hex10_copy = deprecated_hex10.replace()
+
+        self.assertNotEquals(deprecated_hex10, deprecated_hex11)
+        self.assertEquals(deprecated_hex10, deprecated_hex10_copy)
+        self.assertEquals(HexKey(10), deprecated_hex10)
+        self.assertEquals(HexKey(11), deprecated_hex11)
+        self.assertEquals(HexKey(10, deprecated=False), not_deprecated_hex10)
+
+        self.assertTrue(deprecated_hex11.deprecated)
+        self.assertTrue(deprecated_hex10_copy.deprecated)
+        self.assertFalse(not_deprecated_hex10.deprecated)
+
     def test_copy(self):
         original = DictKey({'foo': 'bar'})
         copied = copy.copy(original)


### PR DESCRIPTION
@cpennington @flowerhack @dianakhuang 
The replace function wasn't transmitting the deprecation property to the new object. This should fix that.

I'm 100% sure where I should put the unit test for this. Suggestions?
