### PR TITLE
Version is a property, don't invoke or define as a method

### DIFF
--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -8,7 +8,7 @@ import inspect
 import re
 import warnings
 from bson.son import SON
-from abc import abstractmethod
+from abc import abstractmethod, abstractproperty
 
 from bson.objectid import ObjectId
 from bson.errors import InvalidId
@@ -51,7 +51,7 @@ class Locator(OpaqueKey):
         """
         return unicode(self).encode('utf-8')
 
-    @abstractmethod
+    @abstractproperty
     def version(self):  # pragma: no cover
         """
         Returns the ObjectId referencing this specific location.
@@ -235,6 +235,7 @@ class CourseLocator(BlockLocatorBase, CourseKey):
         if regexp.search(val) is not None:
             raise InvalidKeyError(cls, "Invalid characters in {!r}.".format(val))
 
+    @property
     def version(self):
         """
         Deprecated. The ambiguously named field from CourseLocation which code
@@ -909,14 +910,14 @@ class VersionTree(object):
         """
         if not isinstance(locator, Locator) and not inspect.isabstract(locator):
             raise TypeError("locator {} must be a concrete subclass of Locator".format(locator))
-        if not locator.version():
+        if not locator.version:
             raise ValueError("locator must be version specific (Course has version_guid or definition had id)")
         self.locator = locator
         if tree_dict is None:
             self.children = []
         else:
             self.children = [VersionTree(child, tree_dict)
-                             for child in tree_dict.get(locator.version(), [])]
+                             for child in tree_dict.get(locator.version, [])]
 
 
 class AssetLocator(BlockUsageLocator, AssetKey):

--- a/opaque_keys/edx/tests/test_course_locators.py
+++ b/opaque_keys/edx/tests/test_course_locators.py
@@ -90,7 +90,7 @@ class TestCourseKeys(LocatorBaseTest, TestDeprecated):
         self.assertEqual(testobj_1._to_string(), testobj_1_string)
         self.assertEqual(str(testobj_1), u'course-locator:' + testobj_1_string)
         self.assertEqual(testobj_1.html_id(), u'course-locator:' + testobj_1_string)
-        self.assertEqual(testobj_1.version(), test_id_1)
+        self.assertEqual(testobj_1.version, test_id_1)
 
         # Test using a given string
         test_id_2_loc = '519665f6223ebd6980884f2b'
@@ -104,7 +104,7 @@ class TestCourseKeys(LocatorBaseTest, TestDeprecated):
         self.assertEqual(testobj_2._to_string(), testobj_2_string)
         self.assertEqual(str(testobj_2), u'course-locator:' + testobj_2_string)
         self.assertEqual(testobj_2.html_id(), u'course-locator:' + testobj_2_string)
-        self.assertEqual(testobj_2.version(), test_id_2)
+        self.assertEqual(testobj_2.version, test_id_2)
 
     @ddt.data(
         ' mit.eecs',


### PR DESCRIPTION
@cpennington this should be a property, no? It's causing test failures in edx-platform that this is being invoked as a method. And we define it as a property in BlockUsageLocator (https://github.com/edx/opaque-keys/blob/master/opaque_keys/edx/locator.py#L655) but not in CourseLocator.
