### PR TITLE
Throw deprecation warnings one level up (out of opaque-keys module)

### DIFF
--- a/opaque_keys/edx/locations.py
+++ b/opaque_keys/edx/locations.py
@@ -22,7 +22,8 @@ class i4xEncoder(real_i4xEncoder):  # pylint: disable=invalid-name
         """Deprecated. Use :class:`keys.i4xEncoder.default`"""
         warnings.warn(
             "locations.i4xEncoder.default is deprecated! Please use keys.i4xEncoder.default",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         super(i4xEncoder, self).__init__(*args, **kwargs)
 
@@ -32,7 +33,8 @@ class SlashSeparatedCourseKey(CourseLocator):
     def __init__(self, org, course, run, **kwargs):
         warnings.warn(
             "SlashSeparatedCourseKey is deprecated! Please use locator.CourseLocator",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         super(SlashSeparatedCourseKey, self).__init__(org, course, run, deprecated=True, **kwargs)
 
@@ -41,7 +43,8 @@ class SlashSeparatedCourseKey(CourseLocator):
         """Deprecated. Use :class:`locator.CourseLocator.from_string`"""
         warnings.warn(
             "SlashSeparatedCourseKey is deprecated! Please use locator.CourseLocator",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return CourseLocator.from_string(serialized)
 
@@ -50,7 +53,8 @@ class SlashSeparatedCourseKey(CourseLocator):
         """Deprecated. Use :meth:`locator.CourseLocator.from_string`."""
         warnings.warn(
             "SlashSeparatedCourseKey is deprecated! Please use locator.CourseLocator",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return CourseLocator.from_string(serialized)
 
@@ -83,19 +87,19 @@ class LocationBase(object):
             warnings.warn(
                 "Location is deprecated! Please use locator.BlockUsageLocator",
                 DeprecationWarning,
-                stacklevel=2
+                stacklevel=3
             )
         elif issubclass(cls, AssetLocation):
             warnings.warn(
                 "AssetLocation is deprecated! Please use locator.AssetLocator",
                 DeprecationWarning,
-                stacklevel=2
+                stacklevel=3
             )
         else:
             warnings.warn(
                 "{} is deprecated!".format(cls),
                 DeprecationWarning,
-                stacklevel=2
+                stacklevel=3
             )
 
     @property
@@ -103,7 +107,8 @@ class LocationBase(object):
         """Deprecated. Returns the deprecated tag for this Location."""
         warnings.warn(
             "Tag is no longer supported as a property of Locators.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return self.DEPRECATED_TAG
 

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -186,7 +186,8 @@ class CourseLocator(BlockLocatorBase, CourseKey):
         if offering_arg:
             warnings.warn(
                 "offering is deprecated! Use course and run instead.",
-                DeprecationWarning
+                DeprecationWarning,
+                stacklevel=2
             )
             course, __, run = offering_arg.partition("/")
 
@@ -242,7 +243,8 @@ class CourseLocator(BlockLocatorBase, CourseKey):
         """
         warnings.warn(
             "version is no longer supported as a property of Locators. Please use the version_guid property.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return self.version_guid
 
@@ -253,7 +255,8 @@ class CourseLocator(BlockLocatorBase, CourseKey):
         """
         warnings.warn(
             "Offering is no longer a supported property of Locator. Please use the course and run properties.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         if not self.course and not self.run:
             return None
@@ -306,7 +309,8 @@ class CourseLocator(BlockLocatorBase, CourseKey):
         """
         warnings.warn(
             "make_usage_key_from_deprecated_string is deprecated! Please use make_usage_key",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return BlockUsageLocator.from_string(location_url).replace(run=self.run)
 
@@ -367,7 +371,8 @@ class CourseLocator(BlockLocatorBase, CourseKey):
         """Deprecated. Use unicode(key) instead."""
         warnings.warn(
             "to_deprecated_string is deprecated! Use unicode(key) instead.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return unicode(self)
 
@@ -629,7 +634,8 @@ class BlockUsageLocator(BlockLocatorBase, UsageKey):
         """
         warnings.warn(
             "Offering is no longer a supported property of Locator. Please use the course and run properties.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         if not self.course and not self.run:
             return None
@@ -660,7 +666,8 @@ class BlockUsageLocator(BlockLocatorBase, UsageKey):
         """
         warnings.warn(
             "Version is no longer supported as a property of Locators. Please use the version_guid property.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
 
         """Returns the version guid for this object."""
@@ -674,7 +681,8 @@ class BlockUsageLocator(BlockLocatorBase, UsageKey):
         """
         warnings.warn(
             "Name is no longer supported as a property of Locators. Please use the block_id property.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return self.block_id
 
@@ -686,7 +694,8 @@ class BlockUsageLocator(BlockLocatorBase, UsageKey):
         """
         warnings.warn(
             "Category is no longer supported as a property of Locators. Please use the block_type property.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return self.block_type
 
@@ -698,7 +707,8 @@ class BlockUsageLocator(BlockLocatorBase, UsageKey):
         """
         warnings.warn(
             "Revision is no longer supported as a property of Locators. Please use the branch property.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return self.branch
 
@@ -769,7 +779,8 @@ class BlockUsageLocator(BlockLocatorBase, UsageKey):
         """Deprecated. Use unicode(key) instead."""
         warnings.warn(
             "to_deprecated_string is deprecated! Use unicode(key) instead.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return unicode(self)
 
@@ -972,7 +983,8 @@ class AssetLocator(BlockUsageLocator, AssetKey):
         """Deprecated. Use unicode(key) instead."""
         warnings.warn(
             "to_deprecated_string is deprecated! Use unicode(key) instead.",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         return unicode(self)
 


### PR DESCRIPTION
@cpennington @mmprandom 

Means that in tests, deprecation warnings will look like this:

``` python
good_location = SlashSeparatedCourseKey('testOrg', 'testCourse', 'RunBabyRun')
/Users/sarina/edx_all/edx-platform/common/djangoapps/student/tests/test_course_listing.py:98: DeprecationWarning: SlashSeparatedCourseKey is deprecated! Please use locator.CourseLocator
  course_location = SlashSeparatedCourseKey('testOrg', 'doomedCourse', 'RunBabyRun')
```

rather than

```
/Users/sarina/.virtualenvs/edx-platform/src/opaque-keys/opaque_keys/edx/locations.py:44: DeprecationWarning: SlashSeparatedCourseKey is deprecated! Please use locator.CourseLocator
  DeprecationWarning
```
