### PR TITLE
Ensure pymongo is installed when running setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setup(
         "opaque_keys.edx",
     ],
     install_requires=[
-        "stevedore"
+        "stevedore",
+        "pymongo"
     ],
     entry_points={
         'opaque_keys.testing': [


### PR DESCRIPTION
I missed this when updating the requirements.txt, thought it was automatically pulled in from there.

@cpennington @sarina 
