### PR TITLE
Prevent replace from creating new OpaqueKey objects that are the same as...

### DIFF
--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -316,9 +316,12 @@ class OpaqueKey(object):
         ``KEY_FIELDS``.
         """
         existing_values = {key: getattr(self, key) for key in self.KEY_FIELDS}  # pylint: disable=no-member
+        existing_values['deprecated'] = self.deprecated
+
+        if all(value == existing_values[key] for (key, value) in kwargs.iteritems()):
+            return self
+
         existing_values.update(kwargs)
-        if 'deprecated' not in existing_values:
-            existing_values['deprecated'] = self.deprecated
         return type(self)(**existing_values)
 
     def __setattr__(self, name, value):

--- a/opaque_keys/tests/test_opaque_keys.py
+++ b/opaque_keys/tests/test_opaque_keys.py
@@ -192,7 +192,7 @@ class KeyTests(TestCase):
         hex_copy = hex10.replace()
 
         self.assertNotEquals(id(hex10), id(hex11))
-        self.assertNotEquals(id(hex10), id(hex_copy))
+        self.assertEquals(id(hex10), id(hex_copy))
         self.assertNotEquals(hex10, hex11)
         self.assertEquals(hex10, hex_copy)
         self.assertEquals(HexKey(10), hex10)


### PR DESCRIPTION
... the object being replaced
