### PR TITLE
Regex does not match asset url when it contains spaces

### DIFF
--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -88,6 +88,7 @@ class BlockLocatorBase(Locator):
     BRANCH_PREFIX = r"branch"
     # Prefix for the block portion of a locator URL
     BLOCK_PREFIX = r"block"
+    BLOCK_ALLOWED_ID_CHARS = r'[\w\-~.:%]'
 
     ALLOWED_ID_RE = re.compile(r'^' + Locator.ALLOWED_ID_CHARS + '+$', re.UNICODE)
     DEPRECATED_ALLOWED_ID_RE = re.compile(r'^' + Locator.DEPRECATED_ALLOWED_ID_CHARS + '+$', re.UNICODE)
@@ -100,9 +101,10 @@ class BlockLocatorBase(Locator):
         ({BRANCH_PREFIX}@(?P<branch>{ALLOWED_ID_CHARS}+){SEP})?
         ({VERSION_PREFIX}@(?P<version_guid>[A-F0-9]+){SEP})?
         ({BLOCK_TYPE_PREFIX}@(?P<block_type>{ALLOWED_ID_CHARS}+){SEP})?
-        ({BLOCK_PREFIX}@(?P<block_id>{ALLOWED_ID_CHARS}+))?
+        ({BLOCK_PREFIX}@(?P<block_id>{BLOCK_ALLOWED_ID_CHARS}+))?
         """.format(
         ALLOWED_ID_CHARS=Locator.ALLOWED_ID_CHARS,
+        BLOCK_ALLOWED_ID_CHARS=BLOCK_ALLOWED_ID_CHARS,
         BRANCH_PREFIX=BRANCH_PREFIX,
         VERSION_PREFIX=Locator.VERSION_PREFIX,
         BLOCK_TYPE_PREFIX=Locator.BLOCK_TYPE_PREFIX,

--- a/opaque_keys/edx/tests/test_asset_locators.py
+++ b/opaque_keys/edx/tests/test_asset_locators.py
@@ -15,6 +15,7 @@ class TestAssetLocators(TestCase):
     """
     Tests of :class:`AssetLocator`
     """
+
     @ddt.data(
         "/c4x/org/course/asset/path",
     )
@@ -48,7 +49,10 @@ class TestAssetLocators(TestCase):
     def test_deprecated_son(self, key_cls, prefix, tag, source):
         source_key = key_cls(*source, deprecated=True)
         son = source_key.to_deprecated_son(prefix=prefix, tag=tag)
-        self.assertEquals(son.keys(), [prefix + key for key in ('tag', 'org', 'course', 'category', 'name', 'revision')])
+        self.assertEquals(
+            son.keys(),
+            [prefix + key for key in ('tag', 'org', 'course', 'category', 'name', 'revision')]
+        )
 
         self.assertEquals(son[prefix + 'tag'], tag)
         self.assertEquals(son[prefix + 'category'], source_key.block_type)
@@ -93,3 +97,19 @@ class TestAssetLocators(TestCase):
             '/c4x/org/course/asset/',
             unicode(CourseKey.from_string('org/course/run').make_asset_key('asset', ''))
         )
+
+    @ddt.data(
+        [
+            "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction%20To%20New.srt.sjson",
+            "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction~To~New.srt.sjson",
+            "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction:To:New.srt.sjson",
+            "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction-To-New.srt.sjson",
+        ],
+    )
+    def test_asset_with_special_character(self, paths):
+        for path in paths:
+            asset_locator = AssetKey.from_string(path)
+            self.assertEquals(
+                path,
+                unicode(asset_locator),
+            )


### PR DESCRIPTION
In course when user uploads an asset which has percentage`%` in their filenames; it faces issue on  `course re-run`.
[opaque_keys/edx/locator.py#L98](https://github.com/edx/opaque-keys/blob/master/opaque_keys/edx/locator.py#L98)
Above `Regex` parses asset names and when an asset has `%` in its `name` this Regex  fails to compile it. *(Split to Split)*

Updated the `Regex` to handle the case where if there is a `%` in asset name, it can parse successfully.

 [TNL2098](https://openedx.atlassian.net/browse/TNL-2098)