### PR TITLE
 Fixed Broken page in "Schedule & Details" due to course image

### DIFF
--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -1252,7 +1252,7 @@ class AssetLocator(BlockUsageLocator, AssetKey):
 
     ALLOWED_ID_RE = BlockUsageLocator.DEPRECATED_ALLOWED_ID_RE
     # Allow empty asset ids. Used to generate a prefix url
-    DEPRECATED_ALLOWED_ID_RE = re.compile(r'^' + Locator.DEPRECATED_ALLOWED_ID_CHARS + '*$', re.UNICODE)
+    DEPRECATED_ALLOWED_ID_RE = re.compile(r'^' + Locator.DEPRECATED_ALLOWED_ID_CHARS + '+$', re.UNICODE)
 
     @property
     def path(self):

--- a/opaque_keys/edx/tests/test_asset_locators.py
+++ b/opaque_keys/edx/tests/test_asset_locators.py
@@ -6,7 +6,6 @@ import ddt
 from unittest import TestCase
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey
-
 from opaque_keys.edx.locator import AssetLocator, CourseLocator
 
 
@@ -90,13 +89,12 @@ class TestAssetLocators(TestCase):
         )
 
     def test_empty_path(self):
+        """ Test InvalidKeyError when asset path is empty """
         with self.assertRaises(InvalidKeyError):
-            CourseKey.from_string('course-v1:org+course+run').make_asset_key('asset', '')
+            CourseKey.from_string('course-locator:org+course+run').make_asset_key('asset', '')
 
-        self.assertEquals(
-            '/c4x/org/course/asset/',
-            unicode(CourseKey.from_string('org/course/run').make_asset_key('asset', ''))
-        )
+        with self.assertRaises(InvalidKeyError):
+            CourseKey.from_string('org/course/run').make_asset_key('asset', '')
 
     @ddt.data(
         [


### PR DESCRIPTION
`Schedule & Details` page of the course was breaking because it had empty `course_image`. 
with the empty image path, the assert locator throws `InvalidKeyError`. 

Mongo & Split were behaving differently, when a asset path is empty. Split raise `InvalidKeyError` but Mongo does not. 

[TNL-2435](https://openedx.atlassian.net/browse/TNL-2435)
