### PR TITLE
Catch UnicodeEncodeError.

### DIFF
--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -233,7 +233,7 @@ class OpaqueKey(object):
             # Cache that the namespace doesn't correspond to a known plugin,
             # so that we don't waste time checking every time we hit
             # a particular unknown namespace (like i4x)
-            raise InvalidKeyError(cls, '{}:*'.format(namespace))
+            raise InvalidKeyError(cls, u'{}:*'.format(namespace))
 
     LOADED_DRIVERS = defaultdict()  # If you change default, change test_default_deprecated
 

--- a/opaque_keys/tests/test_opaque_keys.py
+++ b/opaque_keys/tests/test_opaque_keys.py
@@ -137,6 +137,9 @@ class KeyTests(TestCase):
         with self.assertRaises(InvalidKeyError):
             DummyKey.from_string('dict:abcd')
 
+        with self.assertRaises(InvalidKeyError):
+            DummyKey.from_string(u'\xfb:abcd')
+
     def test_unknown_namespace(self):
         with self.assertRaises(InvalidKeyError):
             DummyKey.from_string('no_namespace:0x10')


### PR DESCRIPTION
@brianhw is this what you had in mind ?
I'm looking to add a test for this, incase of UnicodeDecodeError, should we return nothing or reraise ?