### PR TITLE
Clean literal-used-as-attribute Pylint violations

### DIFF
--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -186,7 +186,7 @@ class OpaqueKey(object):
             return cls.get_namespace_plugin(namespace)._from_string(rest)
         except InvalidKeyError:
             if hasattr(cls, 'deprecated_fallback'):
-                return getattr(cls, 'deprecated_fallback')._from_deprecated_string(serialized)
+                return cls.deprecated_fallback._from_deprecated_string(serialized)
             raise InvalidKeyError(cls, serialized)
 
     @classmethod
@@ -256,7 +256,7 @@ class OpaqueKey(object):
         """
         if hasattr(cls, 'deprecated_fallback'):
             raise AttributeError("Error: cannot register two fallback classes for {!r}.".format(cls))
-        setattr(cls, 'deprecated_fallback', fallback)
+        cls.deprecated_fallback = fallback
 
     # ============= VALUE SEMANTICS ==============
     def __init__(self, *args, **kwargs):

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -1024,7 +1024,7 @@ class BlockUsageLocator(BlockLocatorBase, UsageKey):
         for (dep_field_name, field_name) in [('category', 'block_type'), ('name', 'block_id')]:
             son[prefix + dep_field_name] = getattr(self, field_name)
 
-        son[prefix + 'revision'] = getattr(self.course_key, 'branch')
+        son[prefix + 'revision'] = self.course_key.branch
         return son
 
     @classmethod

--- a/opaque_keys/tests/test_opaque_keys.py
+++ b/opaque_keys/tests/test_opaque_keys.py
@@ -161,7 +161,7 @@ class KeyTests(TestCase):
             key.value = 11  # pylint: disable=attribute-defined-outside-init
 
         with self.assertRaises(AttributeError):
-            delattr(key, 'value')
+            del key.value
 
     def test_equality(self):
         self.assertEquals(DummyKey.from_string('hex:0x10'), DummyKey.from_string('hex:0x10'))

--- a/pylintrc
+++ b/pylintrc
@@ -48,7 +48,7 @@ disable =
 	too-many-arguments,
 	too-many-locals,
 	unused-wildcard-import,
-	duplicate-code,literal-used-as-attribute
+	duplicate-code
 
 [REPORTS]
 output-format = text
@@ -148,4 +148,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# beccb25de54021057bcffdd418a8e56a572a8c9f
+# 34eaa1014ee153fd195488d853ed9e725e43ac35

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -1,5 +1,3 @@
 [MASTER]
 load-plugins = edx_lint.pylint
 
-[MESSAGES CONTROL]
-DISABLE+= ,literal-used-as-attribute


### PR DESCRIPTION
This commit actually fixes the violations rather than ignore them.