### PR TITLE
PERF: Optimize key hashing and equality comparison

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,8 @@
+# 0.3.2
+
+* Simple optimizations to reduce the number of OpaqueKey objects
+  created, and to speed up hashing and equality checks.
+
+----
+
+No changelog was maintained before 0.3.2.

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -9,6 +9,7 @@ formats, and allowing new serialization formats to be installed transparently.
 from _collections import defaultdict
 from abc import ABCMeta, abstractmethod
 from functools import total_ordering
+from weakref import WeakValueDictionary
 
 from six import (
     iteritems,
@@ -98,7 +99,17 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
     Serialization of an :class:`OpaqueKey` is performed by using the :func:`unicode` builtin.
     Deserialization is performed by the :meth:`from_string` method.
     """
-    __slots__ = ('_initialized', 'deprecated')
+    __slots__ = (
+        '_initialized',
+        'deprecated',
+
+        # Performance related
+        '_unicode',  # Cached Unicode representation
+        '_hash',  # Cache of the hash() so we don't have to recompute it so often.
+        '_cached_key',  # Cache _key representation, useful for repeated equality checks.
+        '__weakref__'  # To allow us to use the _cache_pool
+    )
+    _cache_pool = WeakValueDictionary()
 
     KEY_FIELDS = []
     CANONICAL_NAMESPACE = None
@@ -168,10 +179,19 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         """
         Serialize this :class:`OpaqueKey`, in the form ``<CANONICAL_NAMESPACE>:<value of _to_string>``.
         """
+        # OpaqueKeys are often repeatedly serialized, so we cache this value.
+        if self._unicode is not None:
+            return self._unicode
+
+        # TODO Revisit assigning-non-slot comments on pylint upgrade
         if self.deprecated:
             # no namespace on deprecated
-            return self._to_deprecated_string()
-        return self.NAMESPACE_SEPARATOR.join([self.CANONICAL_NAMESPACE, self._to_string()])  # pylint: disable=no-member
+            self._unicode = self._to_deprecated_string()  # pylint: disable=assigning-non-slot
+        else:
+            self._unicode = self.NAMESPACE_SEPARATOR.join(  # pylint: disable=assigning-non-slot
+                [self.CANONICAL_NAMESPACE, self._to_string()]  # pylint: disable=no-member
+            )
+        return self._unicode
 
     @classmethod
     def from_string(cls, serialized):
@@ -183,6 +203,17 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         Args:
             serialized: A stringified form of a :class:`OpaqueKey`
         """
+        # OpaqueKeys are immutable, so we can share them. Sharing the keys gives
+        # three benefits:
+        #    1. It reduces parsing/construction costs for duplicate OpaqueKeys.
+        #    2. It allows us to reduce the number of times we do the computation
+        #       for unicode() and hash() -- these are cached on the individual
+        #       OpaqueKey.
+        #    3. Equality checks between two OpaqueKeys are very cheap if they're
+        #       pointing at the same object (which is a frequent occurrence).
+        if serialized in cls._cache_pool:
+            return cls._cache_pool[serialized]
+
         if serialized is None:
             raise InvalidKeyError(cls, serialized)
 
@@ -191,10 +222,16 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         cls._drivers()
         try:
             namespace, rest = cls._separate_namespace(serialized)
-            return cls.get_namespace_plugin(namespace)._from_string(rest)
+            key = cls.get_namespace_plugin(namespace)._from_string(rest)
+            key._unicode = serialized
+            cls._cache_pool[serialized] = key
+            return key
         except InvalidKeyError:
             if hasattr(cls, 'deprecated_fallback'):
-                return cls.deprecated_fallback._from_deprecated_string(serialized)
+                key = cls.deprecated_fallback._from_deprecated_string(serialized)
+                key._unicode = serialized
+                cls._cache_pool[serialized] = key
+                return key
             raise InvalidKeyError(cls, serialized)
 
     @classmethod
@@ -271,6 +308,10 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         # The __init__ expects child classes to implement KEY_FIELDS
         # pylint: disable=no-member
 
+        # TODO Revisit assigning-non-slot comments on pylint upgrade
+        self._unicode = None  # pylint: disable=assigning-non-slot
+        self._cached_key = None  # pylint: disable=assigning-non-slot
+
         # a flag used to indicate that this instance was deserialized from the
         # deprecated form and should serialize to the deprecated form
         self.deprecated = kwargs.pop('deprecated', False)  # pylint: disable=assigning-non-slot
@@ -279,6 +320,7 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
             self._checked_init(*args, **kwargs)
         else:
             self._unchecked_init(**kwargs)
+
         self._initialized = True  # pylint: disable=assigning-non-slot
 
     def _checked_init(self, *args, **kwargs):
@@ -327,10 +369,11 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
             return self
 
         existing_values.update(kwargs)
+
         return type(self)(**existing_values)
 
     def __setattr__(self, name, value):
-        if getattr(self, '_initialized', False):
+        if name != '_unicode' and name != '_hash' and name != '_cached_key' and getattr(self, '_initialized', False):
             raise AttributeError("Can't set {!r}. OpaqueKeys are immutable.".format(name))
 
         super(OpaqueKey, self).__setattr__(name, value)  # pylint: disable=no-member
@@ -357,6 +400,8 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
             if key in self.KEY_FIELDS:  # pylint: disable=no-member
                 setattr(self, key, state_dict[key])
         self.deprecated = state_dict['deprecated']  # pylint: disable=assigning-non-slot
+        self._unicode = None  # pylint: disable=assigning-non-slot
+        self._cached_key = None  # pylint: disable=assigning-non-slot
         self._initialized = True  # pylint: disable=assigning-non-slot
 
     def __getstate__(self):
@@ -370,11 +415,20 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
     @property
     def _key(self):
         """Returns a tuple of key fields"""
-        # pylint: disable=no-member
-        return tuple(getattr(self, field) for field in self.KEY_FIELDS) + (self.CANONICAL_NAMESPACE, self.deprecated)
+        if self._cached_key is not None:
+            return self._cached_key
+        self._cached_key = (  # pylint: disable=assigning-non-slot
+            tuple(getattr(self, field) for field in self.KEY_FIELDS) +
+            (self.CANONICAL_NAMESPACE, self.deprecated)
+        )
+        return self._cached_key
 
     def __eq__(self, other):
-        return isinstance(other, OpaqueKey) and self._key == other._key  # pylint: disable=protected-access
+        if self is other:
+            return True
+        if not isinstance(other, OpaqueKey) or hash(self) != hash(other):
+            return False
+        return self._key == other._key  # pylint: disable=protected-access
 
     def __ne__(self, other):
         return not self == other
@@ -386,7 +440,31 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         return self._key < other._key  # pylint: disable=protected-access
 
     def __hash__(self):
-        return hash(self._key)
+        """
+        Return a hash of the OpaqueKey.
+
+        This method looks a little goofy for performance reasons. OpaqueKeys are
+        everywhere in the system. Grading can result in hundreds of thousands of
+        calls to __hash__ OpaqueKeys for various dict lookups. A single
+        OpaqueKey might be asked for its hash 10-100X during a request.
+
+        To make it as fast as possible, we:
+
+        1. Optimistically return self._hash, so we can avoid the extra dict
+           lookup that comes from checking hasattr.
+        2. Explicitly store ._hash as an integer so that we're not recomputing
+           anything complicated.
+
+        Please be careful when touching this method, since small changes could
+        introduce serious performance regressions. ALWAYS PROFILE on something
+        like the progress or courseware pages when modifying.
+        """
+        try:
+            return self._hash
+        except AttributeError:
+            self._hash = hash(self._key)  # pylint: disable=assigning-non-slot, attribute-defined-outside-init
+
+        return self._hash
 
     def __repr__(self):
         return '{}({})'.format(

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -8,8 +8,10 @@ import inspect
 import logging
 import re
 import warnings
+from weakref import WeakValueDictionary
 from abc import abstractproperty
 from six import string_types, text_type
+from six.moves import zip  # pylint: disable=redefined-builtin
 
 from bson.errors import InvalidId
 from bson.objectid import ObjectId
@@ -151,6 +153,11 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
     __slots__ = KEY_FIELDS
     CHECKED_INIT = False
 
+    # A mapping of parsed key fields to CourseLocator objects, for caching.
+    # This is shared across all subclasses, so we use the class as part of the
+    # keys.
+    __parsed_fields_to_keys = WeakValueDictionary()
+
     # Characters that are forbidden in the deprecated format
     INVALID_CHARS_DEPRECATED = re.compile(r"[^\w.%-]", re.UNICODE)
 
@@ -260,7 +267,45 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
         if parse['version_guid']:
             parse['version_guid'] = cls.as_object_id(parse['version_guid'])
 
-        return cls(**{key: parse.get(key) for key in cls.KEY_FIELDS})
+        parsed_values = tuple(parse.get(key) for key in cls.KEY_FIELDS)
+
+        # Include the class in the cache key so that we don't have collisions
+        # with sub-classes.
+        cache_key = (cls.__class__, parsed_values)
+
+        # Note that this is very often called from UsageKey._from_string() and
+        # fed the serialized ID without the prefix (so no "course-v1:"), but
+        # with a lot of extra non-course-locator stuff at the end. That's why we
+        # can't just use cls._cache_pool directly with "serialized" and instead
+        # have to use parsed_values as a lookup key. The regex parsing of values
+        # is only about 1/4th as expensive as CourseLocator construction, and
+        # that doesn't count the much higher cost of hash and eq calculations
+        # that are avoided by using a shared CourseLocator object.
+        if cache_key in cls.__parsed_fields_to_keys:
+            return cls.__parsed_fields_to_keys[cache_key]
+
+        # So you would *think* that because we're pulling all the fields in
+        # KEY_FIELDS order, it's safe to say::
+        #
+        #   course_locator = cls(*parsed_values)
+        #
+        # However, some subclasses override __init__ to take a **kwargs only,
+        # and this would break compatibility. Which is a pity, because that
+        # would have been faster. :-(
+        course_locator = cls(**dict(zip(cls.KEY_FIELDS, parsed_values)))
+
+        # Serialization is safe because this method is not invoked for
+        # deprecated keys, and so they're always safe to serialize (deprecated
+        # keys can explode because the run is None).
+        full_serialized_key = text_type(course_locator)
+
+        # Write to both our parsed fields cache (needed for when we're called
+        # directly), as well as the OpaqueKey general _cache_pool (for when
+        # we're invoked from OpaqueKey.from_string()).
+        cls.__parsed_fields_to_keys[cache_key] = course_locator
+        cls._cache_pool[full_serialized_key] = course_locator
+
+        return course_locator
 
     def html_id(self):
         """
@@ -308,6 +353,9 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
         Raises:
             ValueError: if the block locator has no org & course, run
         """
+        # Short circuit what is by far the most common case.
+        if self.version_guid is None:
+            return self
         return self.replace(version_guid=None)
 
     def course_agnostic(self):
@@ -326,6 +374,10 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
         """
         if self.org is None:
             raise InvalidKeyError(self.__class__, "Branches must have full course ids not just versions")
+
+        # Short circuit what is by far the most common case.
+        if branch == self.branch and self.version_guid is None:
+            return self
         return self.replace(branch=branch, version_guid=None)
 
     def for_version(self, version_guid):
@@ -914,6 +966,10 @@ class BlockUsageLocator(BlockLocatorBase, UsageKey):
         Return a new instance which has the this block_id in the given course
         :param course_key: a CourseKey object representing the new course to map into
         """
+        # This is usually the case, especially in Split courses, where the key
+        # already exists on the usage key by default.
+        if course_key == self.course_key:
+            return self
         return self.replace(course_key=course_key)
 
     def _to_string(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-opaque-keys',
-    version='0.3.1',
+    version='0.3.2',  # Please update CHANGELOG when you bump versions
     author='edX',
     url='https://github.com/edx/opaque-keys',
     packages=find_packages(),


### PR DESCRIPTION
Okay folks, thank you for your patience. I think this is now in a reviewable state.

Looking at the progress page of a fairly large course (~1.3K blocks) here are three things that happen over and over to OpaqueKeys 

1. Hashing (114K times)
2. Serialization to unicode (49K times)
3. Equality checks (19K times)

This PR tries to address those issues by:

1. Storing the hash explicitly as an integer attribute, so we can throw it back with no work.
2. Storing the serialized unicode representation (which is simple, since that's usually how it's constructed).
3. Intern the OpaqueKeys.

The third one helps avoiding the extra work of hashing and serialization, but it also makes equality faster because we can short circuit them using object identity and hash value (both of which are cheap to check).

My biggest concern is the possible memory leak in the explicit cache pool. I use a `WeakValueDictionary`, but I don't know as that's enough. On the bright side, I think we create far fewer OpaqueKeys during a given request now...

@nedbat, @nasthagiri, @doctoryes, @cpennington: May I get a review from two of you folks?