### PR TITLE
Adds util.get_filename_safe_course_id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+# 0.3.3
+
+* Adds opaque_keys.edx.util.get_filename_course_id()
+
+----
 # 0.3.2
 
 * Simple optimizations to reduce the number of OpaqueKey objects

--- a/opaque_keys/edx/tests/test_util.py
+++ b/opaque_keys/edx/tests/test_util.py
@@ -1,0 +1,76 @@
+"""Test the opaque key utility functions."""
+
+from unittest import TestCase
+
+from opaque_keys.edx.locator import CourseLocator
+from opaque_keys.edx.util import get_filename_safe_course_id
+
+
+VALID_COURSE_ID = u'{}'.format(CourseLocator(org='org', course='course_id', run='course_run'))
+VALID_LEGACY_COURSE_ID = "org/course_id/course_run"
+INVALID_LEGACY_COURSE_ID = "org:course_id:course_run"
+INVALID_NONASCII_LEGACY_COURSE_ID = u"org/course\ufffd_id/course_run"
+VALID_NONASCII_LEGACY_COURSE_ID = u"org/cours\u00e9_id/course_run"
+
+
+class UtilityTests(TestCase):
+    """Tests the methods in the util module."""
+
+    def test_get_safe_filename(self):
+        self.assertEqual(get_filename_safe_course_id(VALID_COURSE_ID), "org_course_id_course_run")
+        self.assertEqual(get_filename_safe_course_id(VALID_COURSE_ID, '-'), "org-course_id-course_run")
+
+    def test_get_filename_with_colon(self):
+        course_id = u'{}'.format(CourseLocator(org='org', course='course:id', run='course:run'))
+        self.assertEqual(get_filename_safe_course_id(VALID_COURSE_ID), "org_course_id_course_run")
+        self.assertEqual(get_filename_safe_course_id(course_id, '-'), "org-course-id-course-run")
+
+    def test_get_filename_for_legacy_id(self):
+        self.assertEqual(
+            get_filename_safe_course_id(VALID_LEGACY_COURSE_ID),
+            "org_course_id_course_run"
+        )
+        self.assertEqual(
+            get_filename_safe_course_id(VALID_LEGACY_COURSE_ID, '-'),
+            "org-course_id-course_run"
+        )
+
+    def test_get_filename_for_invalid_id(self):
+        self.assertEqual(
+            get_filename_safe_course_id(INVALID_LEGACY_COURSE_ID),
+            "org_course_id_course_run"
+        )
+        self.assertEqual(
+            get_filename_safe_course_id(INVALID_LEGACY_COURSE_ID, '-'),
+            "org-course_id-course_run"
+        )
+
+    def test_get_filename_for_nonascii_id(self):
+        # VALID_NONASCII_LEGACY_COURSE_ID contains an alphanumeric unicode character,
+        # so it does not get replaced.
+        self.assertEqual(
+            get_filename_safe_course_id(VALID_NONASCII_LEGACY_COURSE_ID),
+            u"org_cours\u00e9_id_course_run"
+        )
+        self.assertEqual(
+            get_filename_safe_course_id(VALID_NONASCII_LEGACY_COURSE_ID, '-'),
+            u"org-cours\u00e9_id-course_run"
+        )
+        self.assertEqual(
+            get_filename_safe_course_id(VALID_NONASCII_LEGACY_COURSE_ID, u'\u00B6'),
+            u"org\u00B6cours\u00e9_id\u00B6course_run"
+        )
+        # INVALID_NONASCII_LEGACY_COURSE_ID contains a non-alphanimeric unicode character,
+        # so it gets replaced.
+        self.assertEqual(
+            get_filename_safe_course_id(INVALID_NONASCII_LEGACY_COURSE_ID),
+            u"org_course__id_course_run"
+        )
+        self.assertEqual(
+            get_filename_safe_course_id(INVALID_NONASCII_LEGACY_COURSE_ID, '-'),
+            u"org-course-_id-course_run"
+        )
+        self.assertEqual(
+            get_filename_safe_course_id(INVALID_NONASCII_LEGACY_COURSE_ID, u'\u00B6'),
+            u"org\u00B6course\u00B6_id\u00B6course_run"
+        )

--- a/opaque_keys/edx/util.py
+++ b/opaque_keys/edx/util.py
@@ -1,0 +1,22 @@
+"""Utility functions for opaque keys."""
+import re
+
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+
+def get_filename_safe_course_id(course_id, replacement_char='_'):
+    """
+    Create a representation of a course_id that can be used safely in a filepath.
+    """
+    try:
+        course_key = CourseKey.from_string(course_id)
+        filename = replacement_char.join([course_key.org, course_key.course, course_key.run])
+    except InvalidKeyError:
+        # If the course_id doesn't parse, we will still return a value here.
+        filename = course_id
+
+    # The safest characters are A-Z, a-z, 0-9, <underscore>, <period> and <hyphen>.
+    # We represent the first four with \w and the re.UNICODE flag, which covers
+    # ASCII and unicode alphanumeric characters.
+    return re.sub(r'[^\w\.\-]', replacement_char, filename, flags=re.UNICODE)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-opaque-keys',
-    version='0.3.2',  # Please update CHANGELOG when you bump versions
+    version='0.3.3',  # Please update CHANGELOG when you bump versions
     author='edX',
     url='https://github.com/edx/opaque-keys',
     packages=find_packages(),


### PR DESCRIPTION
Adds `edx.opaque_keys.util.get_filename_safe_course_id()` and bumps version to 0.3.3.

This change is required by [edx-analytics-data-api PR #131](https://github.com/edx/edx-analytics-data-api/pull/131) to locate the course report filenames generated by [edx-analytics-pipeline PR #274](https://github.com/edx/edx-analytics-pipeline/pull/274).

`get_filename_safe_course_id` is currently defined (identically) in:
- [edx-analytics-pipeline opaque_key_util](https://github.com/edx/edx-analytics-pipeline/blob/2bd27a516be103ca0cd5c833db553045115992aa/edx/analytics/tasks/util/opaque_key_util.py#L61-L75)
- [edx-analytics-exporter.course_export](https://github.com/edx/edx-analytics-exporter/blob/25df95b21370a5640013d6e259b1f40db5fed377/exporter/course_export.py#L144-L158) 

**Discussions**: Change [proposed on edx-code mailing list](https://groups.google.com/d/msgid/edx-code/08b5861c-591d-412a-b1c3-9bb7ad4b4498%40googlegroups.com).

**Dependencies**: None

**Testing instructions**:

```
make requirements test quality
```

**Author notes and concerns**:
1. This change also adds support for unicode `course_id`s, which was a [TODO in edx-analytics-pipeline](https://github.com/edx/edx-analytics-pipeline/blob/2bd27a516be103ca0cd5c833db553045115992aa/edx/analytics/tasks/util/opaque_key_util.py#L74).

**Reviewers**
- [ ] OpenCraft reviewer TBD
- [ ] edX reviewer[s] TBD
