### PR TITLE
Protect keys/locators against trailing newlines.

### DIFF
--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -121,7 +121,20 @@ class BlockLocatorBase(Locator):
         Raises:
             InvalidKeyError: if string cannot be parsed -or- string ends with a newline.
         """
-        # URL_RE above cannot detect a single trailing newline, so guard against them.
+        # URL_RE above cannot detect a single trailing newline, so guard against them
+        # by detecting them separately. An example to demonstrate:
+        #
+        # >>> import re
+        # >>> x = re.compile('(.+)$')
+        # >>> print x.match('foo')
+        # <_sre.SRE_Match object at 0x107df4510>
+        # >>> print x.match('foo\n')
+        # <_sre.SRE_Match object at 0x107df4510>
+        # >>> print x.match('foo\n\n')
+        # None
+        #
+        # The final regex-captured group will *not* capture a trailing newline.
+        # But parse the string strictly with no trailing newlines allowed.
         if string.endswith('\n'):
             raise InvalidKeyError(cls, string)
 

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -96,7 +96,7 @@ class BlockLocatorBase(Locator):
         ({BRANCH_PREFIX}@(?P<branch>{ALLOWED_ID_CHARS}+){SEP})?
         ({VERSION_PREFIX}@(?P<version_guid>[A-F0-9]+){SEP})?
         ({BLOCK_TYPE_PREFIX}@(?P<block_type>{ALLOWED_ID_CHARS}+){SEP})?
-        ({BLOCK_PREFIX}@(?P<block_id>{BLOCK_ALLOWED_ID_CHARS}+))?\Z
+        ({BLOCK_PREFIX}@(?P<block_id>{BLOCK_ALLOWED_ID_CHARS}+))?
         """.format(
         ALLOWED_ID_CHARS=Locator.ALLOWED_ID_CHARS,
         BLOCK_ALLOWED_ID_CHARS=BLOCK_ALLOWED_ID_CHARS,
@@ -107,7 +107,7 @@ class BlockLocatorBase(Locator):
         SEP=r'(\+(?=.)|\Z)',  # Separator: requires a non-trailing '+' or end of string
     )
 
-    URL_RE = re.compile('^' + URL_RE_SOURCE + '$', re.IGNORECASE | re.VERBOSE | re.UNICODE)
+    URL_RE = re.compile('^' + URL_RE_SOURCE + r'\Z', re.IGNORECASE | re.VERBOSE | re.UNICODE)
 
     @classmethod
     def parse_url(cls, string):

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -96,7 +96,7 @@ class BlockLocatorBase(Locator):
         ({BRANCH_PREFIX}@(?P<branch>{ALLOWED_ID_CHARS}+){SEP})?
         ({VERSION_PREFIX}@(?P<version_guid>[A-F0-9]+){SEP})?
         ({BLOCK_TYPE_PREFIX}@(?P<block_type>{ALLOWED_ID_CHARS}+){SEP})?
-        ({BLOCK_PREFIX}@(?P<block_id>{BLOCK_ALLOWED_ID_CHARS}+))?
+        ({BLOCK_PREFIX}@(?P<block_id>{BLOCK_ALLOWED_ID_CHARS}+))?\Z
         """.format(
         ALLOWED_ID_CHARS=Locator.ALLOWED_ID_CHARS,
         BLOCK_ALLOWED_ID_CHARS=BLOCK_ALLOWED_ID_CHARS,
@@ -104,7 +104,7 @@ class BlockLocatorBase(Locator):
         VERSION_PREFIX=Locator.VERSION_PREFIX,
         BLOCK_TYPE_PREFIX=Locator.BLOCK_TYPE_PREFIX,
         BLOCK_PREFIX=BLOCK_PREFIX,
-        SEP=r'(\+(?=.)|$)',  # Separator: requires a non-trailing '+' or end of string
+        SEP=r'(\+(?=.)|\Z)',  # Separator: requires a non-trailing '+' or end of string
     )
 
     URL_RE = re.compile('^' + URL_RE_SOURCE + '$', re.IGNORECASE | re.VERBOSE | re.UNICODE)
@@ -121,23 +121,6 @@ class BlockLocatorBase(Locator):
         Raises:
             InvalidKeyError: if string cannot be parsed -or- string ends with a newline.
         """
-        # URL_RE above cannot detect a single trailing newline, so guard against them
-        # by detecting them separately. An example to demonstrate:
-        #
-        # >>> import re
-        # >>> x = re.compile('(.+)$')
-        # >>> print x.match('foo')
-        # <_sre.SRE_Match object at 0x107df4510>
-        # >>> print x.match('foo\n')
-        # <_sre.SRE_Match object at 0x107df4510>
-        # >>> print x.match('foo\n\n')
-        # None
-        #
-        # The final regex-captured group will *not* capture a trailing newline.
-        # But parse the string strictly with no trailing newlines allowed.
-        if string.endswith('\n'):
-            raise InvalidKeyError(cls, string)
-
         match = cls.URL_RE.match(string)
         if not match:
             raise InvalidKeyError(cls, string)

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -119,8 +119,12 @@ class BlockLocatorBase(Locator):
         with key 'id' and optional keys 'branch' and 'version_guid'.
 
         Raises:
-            InvalidKeyError: if string cannot be parsed.
+            InvalidKeyError: if string cannot be parsed -or- string ends with a newline.
         """
+        # URL_RE above cannot detect a single trailing newline, so guard against them.
+        if string.endswith('\n'):
+            raise InvalidKeyError(cls, string)
+
         match = cls.URL_RE.match(string)
         if not match:
             raise InvalidKeyError(cls, string)

--- a/opaque_keys/edx/tests/test_asset_locators.py
+++ b/opaque_keys/edx/tests/test_asset_locators.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 
 from six import text_type
 import ddt
+import itertools
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey
@@ -113,3 +114,14 @@ class TestAssetLocators(TestCase):
                 path,
                 text_type(asset_locator),
             )
+
+    @ddt.data(*itertools.product(
+        (
+            "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction_To_New.srt.sjson{}",
+        ),
+        ('\n', '\n\n', ' ', '   ', '   \n'),
+    ))
+    @ddt.unpack
+    def test_asset_with_trailing_whitespace(self, path_fmt, whitespace):
+        with self.assertRaises(InvalidKeyError):
+            AssetKey.from_string(path_fmt.format(whitespace))

--- a/opaque_keys/edx/tests/test_asset_locators.py
+++ b/opaque_keys/edx/tests/test_asset_locators.py
@@ -100,20 +100,17 @@ class TestAssetLocators(TestCase):
             CourseKey.from_string('org/course/run').make_asset_key('asset', '')
 
     @ddt.data(
-        [
-            "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction%20To%20New.srt.sjson",
-            "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction~To~New.srt.sjson",
-            "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction:To:New.srt.sjson",
-            "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction-To-New.srt.sjson",
-        ],
+        "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction%20To%20New.srt.sjson",
+        "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction~To~New.srt.sjson",
+        "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction:To:New.srt.sjson",
+        "asset-v1:UOG+cs_34+Cs128+type@asset+block@subs_Introduction-To-New.srt.sjson",
     )
-    def test_asset_with_special_character(self, paths):
-        for path in paths:
-            asset_locator = AssetKey.from_string(path)
-            self.assertEqual(
-                path,
-                text_type(asset_locator),
-            )
+    def test_asset_with_special_character(self, path):
+        asset_locator = AssetKey.from_string(path)
+        self.assertEqual(
+            path,
+            text_type(asset_locator),
+        )
 
     @ddt.data(*itertools.product(
         (
@@ -125,3 +122,11 @@ class TestAssetLocators(TestCase):
     def test_asset_with_trailing_whitespace(self, path_fmt, whitespace):
         with self.assertRaises(InvalidKeyError):
             AssetKey.from_string(path_fmt.format(whitespace))
+
+    @ddt.data(
+        "asset-v1:UOG+cs_34+Cs128+type@asset",
+        "asset-v1:UOG+cs_34+Cs128",
+    )
+    def test_asset_with_missing_parts(self, path):
+        with self.assertRaises(InvalidKeyError):
+            AssetKey.from_string(path)

--- a/opaque_keys/edx/tests/test_asset_locators.py
+++ b/opaque_keys/edx/tests/test_asset_locators.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from six import text_type
 import ddt
-import itertools
+import itertools  # pylint: disable=wrong-import-order
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey

--- a/opaque_keys/edx/tests/test_block_usage_locators.py
+++ b/opaque_keys/edx/tests/test_block_usage_locators.py
@@ -5,7 +5,7 @@ from itertools import product
 from six import text_type
 
 import ddt
-import itertools
+import itertools  # pylint: disable=wrong-import-order
 from bson.objectid import ObjectId
 
 from opaque_keys import InvalidKeyError

--- a/opaque_keys/edx/tests/test_block_usage_locators.py
+++ b/opaque_keys/edx/tests/test_block_usage_locators.py
@@ -5,6 +5,7 @@ from itertools import product
 from six import text_type
 
 import ddt
+import itertools
 from bson.objectid import ObjectId
 
 from opaque_keys import InvalidKeyError
@@ -23,6 +24,13 @@ GENERAL_PAIRS = [
     ('ab    fg!@//\\aj', 'ab_fg_aj'),
     (u"ab\xA9", "ab_"),  # no unicode allowed for now
 ]
+
+# Block usage locator to use in tests.
+TEST_ID_LOC = '519665f6223ebd6980884f2b'
+BLOCK_URL = 'block-v1:mit.eecs+6002x+2014_T2+{}@draft+{}@{}+{}@problem+{}@lab2'.format(
+    CourseLocator.BRANCH_PREFIX, CourseLocator.VERSION_PREFIX, TEST_ID_LOC,
+    BlockUsageLocator.BLOCK_TYPE_PREFIX, BlockUsageLocator.BLOCK_PREFIX
+)
 
 
 @ddt.ddt
@@ -298,6 +306,17 @@ class TestBlockUsageLocators(LocatorBaseTest):
             block='lab2',
             version_guid=ObjectId(test_id_loc)
         )
+
+    @ddt.data(*itertools.product(
+        (
+            '{}{}'.format(BLOCK_URL, '{}'),
+        ),
+        ('\n', '\n\n', ' ', '   ', '   \n'),
+    ))
+    @ddt.unpack
+    def test_block_constructor_url_trailing_whitespace(self, url_fmt, whitespace):
+        with self.assertRaises(InvalidKeyError):
+            UsageKey.from_string(url_fmt.format(whitespace))
 
     def test_colon_name(self):
         """

--- a/opaque_keys/edx/tests/test_course_locators.py
+++ b/opaque_keys/edx/tests/test_course_locators.py
@@ -4,7 +4,7 @@ Tests of CourseKeys and CourseLocators
 from six import text_type
 
 import ddt
-import itertools
+import itertools  # pylint: disable=wrong-import-order
 
 from bson.objectid import ObjectId
 

--- a/opaque_keys/edx/tests/test_course_locators.py
+++ b/opaque_keys/edx/tests/test_course_locators.py
@@ -4,6 +4,7 @@ Tests of CourseKeys and CourseLocators
 from six import text_type
 
 import ddt
+import itertools
 
 from bson.objectid import ObjectId
 
@@ -152,6 +153,19 @@ class TestCourseKeys(LocatorBaseTest, TestDeprecated):
     def test_course_constructor_bad_url(self, bad_url):
         with self.assertRaises(InvalidKeyError):
             CourseKey.from_string(bad_url)
+
+    @ddt.data(*itertools.product(
+        (
+            'course-v1:mit+course+run{}',
+            'course-v1:mit+course+run+branch@published{}',
+            'course-v1:mit+course+run+branch@published+version@519665f6223ebd6980884f2b{}',
+        ),
+        ('\n', '\n\n', ' ', '   ', '   \n'),
+    ))
+    @ddt.unpack
+    def test_course_constructor_trailing_whitespace(self, url_with_whitespace_fmt, whitespace):
+        with self.assertRaises(InvalidKeyError):
+            CourseKey.from_string(url_with_whitespace_fmt.format(whitespace))
 
     def test_course_constructor_url(self):
         # Test parsing a url when it starts with a version ID and there is also a block ID.

--- a/opaque_keys/edx/tests/test_library_locators.py
+++ b/opaque_keys/edx/tests/test_library_locators.py
@@ -3,7 +3,7 @@ Tests of LibraryLocators
 """
 from six import text_type
 import ddt
-import itertools
+import itertools  # pylint: disable=wrong-import-order
 
 from bson.objectid import ObjectId
 

--- a/opaque_keys/edx/tests/test_library_locators.py
+++ b/opaque_keys/edx/tests/test_library_locators.py
@@ -3,6 +3,7 @@ Tests of LibraryLocators
 """
 from six import text_type
 import ddt
+import itertools
 
 from bson.objectid import ObjectId
 
@@ -31,6 +32,17 @@ class TestLibraryLocators(LocatorBaseTest, TestDeprecated):
     def test_lib_key_from_invalid_string(self, lib_id_str):
         with self.assertRaises(InvalidKeyError):
             LibraryLocator.from_string(lib_id_str)
+
+    @ddt.data(*itertools.product(
+        (
+            "library-v1:TestX+LibY{}",
+        ),
+        ('\n', '\n\n', ' ', '   ', '   \n'),
+    ))
+    @ddt.unpack
+    def test_lib_key_with_trailing_whitespace(self, lib_id_fmt, whitespace):
+        with self.assertRaises(InvalidKeyError):
+            LibraryLocator.from_string(lib_id_fmt.format(whitespace))
 
     def test_lib_key_constructor(self):
         org = 'TestX'

--- a/opaque_keys/edx/tests/test_library_usage_locators.py
+++ b/opaque_keys/edx/tests/test_library_usage_locators.py
@@ -4,6 +4,7 @@ Tests of LibraryUsageLocator
 """
 from six import text_type
 import ddt
+import itertools
 from bson.objectid import ObjectId
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey
@@ -76,6 +77,23 @@ class TestLibraryUsageLocators(LocatorBaseTest):
     def test_constructor_invalid_from_string(self, url):
         with self.assertRaises(InvalidKeyError):
             UsageKey.from_string(url)
+
+    @ddt.data(*itertools.product(
+        (
+            u"lib-block-v1:org+lib+{}@category+{}@name{}".format(BLOCK_TYPE_PREFIX, BLOCK_PREFIX, '{}'),
+            u"lib-block-v1:org+lib+{}@519665f6223ebd6980884f2b+{}@category+{}@name{}".format(
+                VERSION_PREFIX, BLOCK_TYPE_PREFIX, BLOCK_PREFIX, '{}'
+            ),
+            u"lib-block-v1:org+lib+{}@revision+{}@category+{}@name{}".format(
+                LibraryLocator.BRANCH_PREFIX, BLOCK_TYPE_PREFIX, BLOCK_PREFIX, '{}'
+            ),
+        ),
+        ('\n', '\n\n', ' ', '   ', '   \n'),
+    ))
+    @ddt.unpack
+    def test_constructor_invalid_from_string_trailing_whitespace(self, locator_fmt, whitespace):
+        with self.assertRaises(InvalidKeyError):
+            UsageKey.from_string(locator_fmt.format(whitespace))
 
     def test_superclass_make_relative(self):
         lib_key = LibraryLocator(org="TestX", library="problem-bank-15")

--- a/opaque_keys/edx/tests/test_library_usage_locators.py
+++ b/opaque_keys/edx/tests/test_library_usage_locators.py
@@ -4,7 +4,7 @@ Tests of LibraryUsageLocator
 """
 from six import text_type
 import ddt
-import itertools
+import itertools  # pylint: disable=wrong-import-order
 from bson.objectid import ObjectId
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-opaque-keys',
-    version='0.3.3',
+    version='0.3.4',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     packages=find_packages(),


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ECOM-5345

The key url regular expression was flawed in that it allowed trailing newlines. I haven't found a way yet via regex to detect trailing newlines in the complex regex that the code needs, so a separate check for trailing newlines was added. Tests were also added for other important locators/keys.

@cpennington @ormsbee @cpennington @adampalay @feanil @rlucioni PTAL.