### PR TITLE
Re-applying Optimizations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,10 @@
-# Unreleased
+# 0.4.1
+
+* Re-introduce the caching optimizations of 0.3.2, but this time don't blindly
+  assign the argument to OpaqueKey.from_string() to be the key's serialized
+  representation. The OpaqueKey always serializes itself out to whatever its
+  canonical form is. This should be redundant given the other precautions added
+  since 0.3.2, but it's an extra layer of security.
 
 # 0.4
 

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -9,6 +9,7 @@ formats, and allowing new serialization formats to be installed transparently.
 from _collections import defaultdict
 from abc import ABCMeta, abstractmethod
 from functools import total_ordering
+from weakref import WeakValueDictionary
 
 from six import (
     iteritems,
@@ -98,7 +99,17 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
     Serialization of an :class:`OpaqueKey` is performed by using the :func:`unicode` builtin.
     Deserialization is performed by the :meth:`from_string` method.
     """
-    __slots__ = ('_initialized', 'deprecated')
+    __slots__ = (
+        '_initialized',
+        'deprecated',
+
+        # Performance related
+        '_unicode',  # Cached Unicode representation
+        '_hash',  # Cache of the hash() so we don't have to recompute it so often.
+        '_cached_key',  # Cache _key representation, useful for repeated equality checks.
+        '__weakref__'  # To allow us to use the _cache_pool
+    )
+    _cache_pool = WeakValueDictionary()
 
     KEY_FIELDS = []
     CANONICAL_NAMESPACE = None
@@ -168,10 +179,19 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         """
         Serialize this :class:`OpaqueKey`, in the form ``<CANONICAL_NAMESPACE>:<value of _to_string>``.
         """
+        # OpaqueKeys are often repeatedly serialized, so we cache this value.
+        if self._unicode is not None:
+            return self._unicode
+
+        # TODO Revisit assigning-non-slot comments on pylint upgrade
         if self.deprecated:
             # no namespace on deprecated
-            return self._to_deprecated_string()
-        return self.NAMESPACE_SEPARATOR.join([self.CANONICAL_NAMESPACE, self._to_string()])  # pylint: disable=no-member
+            self._unicode = self._to_deprecated_string()  # pylint: disable=assigning-non-slot
+        else:
+            self._unicode = self.NAMESPACE_SEPARATOR.join(  # pylint: disable=assigning-non-slot
+                [self.CANONICAL_NAMESPACE, self._to_string()]  # pylint: disable=no-member
+            )
+        return self._unicode
 
     @classmethod
     def from_string(cls, serialized):
@@ -183,6 +203,17 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         Args:
             serialized: A stringified form of a :class:`OpaqueKey`
         """
+        # OpaqueKeys are immutable, so we can share them. Sharing the keys gives
+        # three benefits:
+        #    1. It reduces parsing/construction costs for duplicate OpaqueKeys.
+        #    2. It allows us to reduce the number of times we do the computation
+        #       for unicode() and hash() -- these are cached on the individual
+        #       OpaqueKey.
+        #    3. Equality checks between two OpaqueKeys are very cheap if they're
+        #       pointing at the same object (which is a frequent occurrence).
+        if serialized in cls._cache_pool:
+            return cls._cache_pool[serialized]
+
         if serialized is None:
             raise InvalidKeyError(cls, serialized)
 
@@ -191,10 +222,14 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         cls._drivers()
         try:
             namespace, rest = cls._separate_namespace(serialized)
-            return cls.get_namespace_plugin(namespace)._from_string(rest)
+            key = cls.get_namespace_plugin(namespace)._from_string(rest)
+            cls._cache_pool[serialized] = key
+            return key
         except InvalidKeyError:
             if hasattr(cls, 'deprecated_fallback'):
-                return cls.deprecated_fallback._from_deprecated_string(serialized)
+                key = cls.deprecated_fallback._from_deprecated_string(serialized)
+                cls._cache_pool[serialized] = key
+                return key
             raise InvalidKeyError(cls, serialized)
 
     @classmethod
@@ -271,6 +306,10 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         # The __init__ expects child classes to implement KEY_FIELDS
         # pylint: disable=no-member
 
+        # TODO Revisit assigning-non-slot comments on pylint upgrade
+        self._unicode = None  # pylint: disable=assigning-non-slot
+        self._cached_key = None  # pylint: disable=assigning-non-slot
+
         # a flag used to indicate that this instance was deserialized from the
         # deprecated form and should serialize to the deprecated form
         self.deprecated = kwargs.pop('deprecated', False)  # pylint: disable=assigning-non-slot
@@ -279,6 +318,7 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
             self._checked_init(*args, **kwargs)
         else:
             self._unchecked_init(**kwargs)
+
         self._initialized = True  # pylint: disable=assigning-non-slot
 
     def _checked_init(self, *args, **kwargs):
@@ -327,10 +367,11 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
             return self
 
         existing_values.update(kwargs)
+
         return type(self)(**existing_values)
 
     def __setattr__(self, name, value):
-        if getattr(self, '_initialized', False):
+        if name != '_unicode' and name != '_hash' and name != '_cached_key' and getattr(self, '_initialized', False):
             raise AttributeError("Can't set {!r}. OpaqueKeys are immutable.".format(name))
 
         super(OpaqueKey, self).__setattr__(name, value)  # pylint: disable=no-member
@@ -357,6 +398,8 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
             if key in self.KEY_FIELDS:  # pylint: disable=no-member
                 setattr(self, key, state_dict[key])
         self.deprecated = state_dict['deprecated']  # pylint: disable=assigning-non-slot
+        self._unicode = None  # pylint: disable=assigning-non-slot
+        self._cached_key = None  # pylint: disable=assigning-non-slot
         self._initialized = True  # pylint: disable=assigning-non-slot
 
     def __getstate__(self):
@@ -370,11 +413,20 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
     @property
     def _key(self):
         """Returns a tuple of key fields"""
-        # pylint: disable=no-member
-        return tuple(getattr(self, field) for field in self.KEY_FIELDS) + (self.CANONICAL_NAMESPACE, self.deprecated)
+        if self._cached_key is not None:
+            return self._cached_key
+        self._cached_key = (  # pylint: disable=assigning-non-slot
+            tuple(getattr(self, field) for field in self.KEY_FIELDS) +
+            (self.CANONICAL_NAMESPACE, self.deprecated)
+        )
+        return self._cached_key
 
     def __eq__(self, other):
-        return isinstance(other, OpaqueKey) and self._key == other._key  # pylint: disable=protected-access
+        if self is other:
+            return True
+        if not isinstance(other, OpaqueKey) or hash(self) != hash(other):
+            return False
+        return self._key == other._key  # pylint: disable=protected-access
 
     def __ne__(self, other):
         return not self == other
@@ -386,7 +438,31 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         return self._key < other._key  # pylint: disable=protected-access
 
     def __hash__(self):
-        return hash(self._key)
+        """
+        Return a hash of the OpaqueKey.
+
+        This method looks a little goofy for performance reasons. OpaqueKeys are
+        everywhere in the system. Grading can result in hundreds of thousands of
+        calls to __hash__ OpaqueKeys for various dict lookups. A single
+        OpaqueKey might be asked for its hash 10-100X during a request.
+
+        To make it as fast as possible, we:
+
+        1. Optimistically return self._hash, so we can avoid the extra dict
+           lookup that comes from checking hasattr.
+        2. Explicitly store ._hash as an integer so that we're not recomputing
+           anything complicated.
+
+        Please be careful when touching this method, since small changes could
+        introduce serious performance regressions. ALWAYS PROFILE on something
+        like the progress or courseware pages when modifying.
+        """
+        try:
+            return self._hash
+        except AttributeError:
+            self._hash = hash(self._key)  # pylint: disable=assigning-non-slot, attribute-defined-outside-init
+
+        return self._hash
 
     def __repr__(self):
         return '{}({})'.format(

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -8,13 +8,15 @@ import inspect
 import logging
 import re
 import warnings
+from weakref import WeakValueDictionary
 from abc import abstractproperty
+from six import string_types, text_type
+from six.moves import zip  # pylint: disable=redefined-builtin
 
 from bson.errors import InvalidId
 from bson.objectid import ObjectId
 from bson.son import SON
 
-from six import string_types, text_type
 from opaque_keys import OpaqueKey, InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey, DefinitionKey, AssetKey
 
@@ -148,6 +150,11 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
     __slots__ = KEY_FIELDS
     CHECKED_INIT = False
 
+    # A mapping of parsed key fields to CourseLocator objects, for caching.
+    # This is shared across all subclasses, so we use the class as part of the
+    # keys.
+    __parsed_fields_to_keys = WeakValueDictionary()
+
     # Characters that are forbidden in the deprecated format
     INVALID_CHARS_DEPRECATED = re.compile(r"[^\w.%-]", re.UNICODE)
 
@@ -257,7 +264,45 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
         if parse['version_guid']:
             parse['version_guid'] = cls.as_object_id(parse['version_guid'])
 
-        return cls(**{key: parse.get(key) for key in cls.KEY_FIELDS})
+        parsed_values = tuple(parse.get(key) for key in cls.KEY_FIELDS)
+
+        # Include the class in the cache key so that we don't have collisions
+        # with sub-classes.
+        cache_key = (cls.__class__, parsed_values)
+
+        # Note that this is very often called from UsageKey._from_string() and
+        # fed the serialized ID without the prefix (so no "course-v1:"), but
+        # with a lot of extra non-course-locator stuff at the end. That's why we
+        # can't just use cls._cache_pool directly with "serialized" and instead
+        # have to use parsed_values as a lookup key. The regex parsing of values
+        # is only about 1/4th as expensive as CourseLocator construction, and
+        # that doesn't count the much higher cost of hash and eq calculations
+        # that are avoided by using a shared CourseLocator object.
+        if cache_key in cls.__parsed_fields_to_keys:
+            return cls.__parsed_fields_to_keys[cache_key]
+
+        # So you would *think* that because we're pulling all the fields in
+        # KEY_FIELDS order, it's safe to say::
+        #
+        #   course_locator = cls(*parsed_values)
+        #
+        # However, some subclasses override __init__ to take a **kwargs only,
+        # and this would break compatibility. Which is a pity, because that
+        # would have been faster. :-(
+        course_locator = cls(**dict(zip(cls.KEY_FIELDS, parsed_values)))
+
+        # Serialization is safe because this method is not invoked for
+        # deprecated keys, and so they're always safe to serialize (deprecated
+        # keys can explode because the run is None).
+        full_serialized_key = text_type(course_locator)
+
+        # Write to both our parsed fields cache (needed for when we're called
+        # directly), as well as the OpaqueKey general _cache_pool (for when
+        # we're invoked from OpaqueKey.from_string()).
+        cls.__parsed_fields_to_keys[cache_key] = course_locator
+        cls._cache_pool[full_serialized_key] = course_locator
+
+        return course_locator
 
     def html_id(self):
         """
@@ -305,6 +350,9 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
         Raises:
             ValueError: if the block locator has no org & course, run
         """
+        # Short circuit what is by far the most common case.
+        if self.version_guid is None:
+            return self
         return self.replace(version_guid=None)
 
     def course_agnostic(self):
@@ -323,6 +371,10 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
         """
         if self.org is None:
             raise InvalidKeyError(self.__class__, "Branches must have full course ids not just versions")
+
+        # Short circuit what is by far the most common case.
+        if branch == self.branch and self.version_guid is None:
+            return self
         return self.replace(branch=branch, version_guid=None)
 
     def for_version(self, version_guid):
@@ -911,6 +963,10 @@ class BlockUsageLocator(BlockLocatorBase, UsageKey):
         Return a new instance which has the this block_id in the given course
         :param course_key: a CourseKey object representing the new course to map into
         """
+        # This is usually the case, especially in Split courses, where the key
+        # already exists on the usage key by default.
+        if course_key == self.course_key:
+            return self
         return self.replace(course_key=course_key)
 
     def _to_string(self):

--- a/opaque_keys/edx/tests/test_block_usage_locators.py
+++ b/opaque_keys/edx/tests/test_block_usage_locators.py
@@ -9,7 +9,7 @@ import itertools  # pylint: disable=wrong-import-order
 from bson.objectid import ObjectId
 
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator, LocalId
 from opaque_keys.edx.tests import LocatorBaseTest
 
@@ -381,3 +381,51 @@ class TestBlockUsageLocators(LocatorBaseTest):
             ).block_id,
             local_id
         )
+
+    def test_general_cache_pool(self):
+        """Calling from_string with the same string returns the same object."""
+        serialized_key = "i4x://org/course/cache_pool/name"
+        key_1 = UsageKey.from_string(serialized_key)
+        key_2 = UsageKey.from_string(serialized_key)
+        self.assertIs(key_1, key_2)
+
+        # The unicode version of the same string should also work.
+        uni_serialized_key = u"i4x://org/course/cache_pool/name"
+        key_3 = UsageKey.from_string(uni_serialized_key)
+        self.assertIs(key_1, key_3)
+
+        # Sanity check
+        diff_serialized_key = u"i4x://org/course/cache_pool/name2"
+        key_4 = UsageKey.from_string(diff_serialized_key)
+        self.assertIsNot(key_1, key_4)
+
+    def test_course_locator_caching(self):
+        """
+        Test that we cache correctly when mapping a UsageKey into a course.
+
+        This is a little complicated by the fact that CourseLocators can be
+        created implicitly when we create a BlockUsageLocator of a block within
+        that course.
+
+        This caching is currently only done with newer-style locators and not
+        the old org/course/run and i4x:// style keys.
+        """
+        usage_key_1 = UsageKey.from_string('block-v1:edX+CacheX+Demo_Course+type@problem+block@1')
+        usage_key_2 = UsageKey.from_string('block-v1:edX+CacheX+Demo_Course+type@problem+block@2')
+        self.assertIs(usage_key_1.course_key, usage_key_2.course_key)
+
+        # Create a new course key and make sure that it points to the same
+        # object as the derived ones created for the UsageKeys above.
+        course_key = CourseKey.from_string('course-v1:edX+CacheX+Demo_Course')
+        self.assertIs(course_key, usage_key_1.course_key)
+        remapped_usage_key = usage_key_1.map_into_course(course_key)
+        self.assertIs(course_key, remapped_usage_key.course_key)
+
+    def test_stripping_branch_noop_returns_original(self):
+        """Stripping branch from a key with no branch returns the original."""
+        usage_key = UsageKey.from_string('block-v1:edX+CacheX+Branch_Demo+type@problem+block@1')
+        stripped_key = usage_key.for_branch(None)
+        self.assertIs(usage_key, stripped_key)
+
+        new_branch_key = usage_key.for_branch("new_branch")
+        self.assertIsNot(usage_key, new_branch_key)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-opaque-keys',
-    version='0.4',
+    version='0.4.1',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[


### PR DESCRIPTION
Minus the horrible issue that caused a hotfix. The value of `._unicode` always has to be derived from the parsed key, instead of trusting input into `from_string`