### PR TITLE
PLAT-1885 Less usage of deprecated properties

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 # Unreleased
 
+# 0.4.1
+
+* Stop an assortment of deprecation warnings by replacing internal usage of
+  deprecated properties.
+* Trailing '/' characters are no longer valid in serialized usage keys.
+
 # 0.4
 
 * Enforce the property that serialized keys are equal if and only if the parsed

--- a/opaque_keys/edx/locations.py
+++ b/opaque_keys/edx/locations.py
@@ -197,9 +197,9 @@ class Location(LocationBase, BlockUsageLocator):
             kwargs.pop('org', self.course_key.org),
             kwargs.pop('course', self.course_key.course),
             kwargs.pop('run', self.course_key.run),
-            kwargs.pop('category', self.category),
-            kwargs.pop('name', self.name),
-            revision=kwargs.pop('revision', self.revision),
+            kwargs.pop('category', self.block_type),
+            kwargs.pop('name', self.block_id),
+            revision=kwargs.pop('revision', self.branch),
             **kwargs
         )
 
@@ -266,9 +266,9 @@ class AssetLocation(LocationBase, AssetLocator):
             kwargs.pop('org', self.org),
             kwargs.pop('course', self.course),
             kwargs.pop('run', self.run),
-            kwargs.pop('category', self.category),
-            kwargs.pop('name', self.name),
-            revision=kwargs.pop('revision', self.revision),
+            kwargs.pop('category', self.block_type),
+            kwargs.pop('name', self.block_id),
+            revision=kwargs.pop('revision', self.branch),
             **kwargs
         )
 

--- a/opaque_keys/edx/tests/test_aside_keys.py
+++ b/opaque_keys/edx/tests/test_aside_keys.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 
 from six import text_type
 import ddt
-from hypothesis import strategies, given, assume
+from hypothesis import HealthCheck, assume, given, settings, strategies
 
 from opaque_keys.edx.asides import (
     AsideUsageKeyV1, AsideDefinitionKeyV1,
@@ -50,6 +50,7 @@ class TestEncode(TestCase):
         self.assertEqual((left, right), (_left, _right))
 
     @given(text=ENCODING_TEXT)
+    @settings(suppress_health_check=[HealthCheck.too_slow])
     def test_decode_v1_roundtrip(self, text):
         """
         Test all combinations that include characters we're trying to encode, or using in the encoding.
@@ -72,6 +73,7 @@ class TestEncode(TestCase):
         self.assertEqual(text, decoded)
 
     @given(text=ENCODING_TEXT)
+    @settings(suppress_health_check=[HealthCheck.too_slow])
     def test_decode_v2_roundtrip(self, text):
         """
         Test all combinations that include characters we're trying to encode, or using in the encoding.

--- a/opaque_keys/edx/tests/test_deprecated_locations.py
+++ b/opaque_keys/edx/tests/test_deprecated_locations.py
@@ -22,7 +22,7 @@ class TestLocationDeprecatedBase(TestDeprecated):
 
         NOTE: This replace function accesses deprecated variables and therefore throws multiple deprecation warnings.
         """
-        with self.assertDeprecationWarning(count=13):
+        with self.assertDeprecationWarning(count=4):
             loc = cls("foo", "bar", "baz", "cat", "name")
             loc_boo = loc.replace(org='boo')
             loc_copy = loc.replace()

--- a/opaque_keys/edx/tests/test_properties.py
+++ b/opaque_keys/edx/tests/test_properties.py
@@ -171,6 +171,11 @@ def perturbed_strings(string_strategy):
     serialized=u'i4x://-/-/-/-@-',
     perturbed=u'/i4x/-/-/-/-@-',
 )
+@example(
+    key_type=UsageKey,
+    serialized=u'i4x://-/-/-/-@-',
+    perturbed=u'i4x://-/-/-/-@-/',
+)
 def test_perturbed_serializations(key_type, serialized, perturbed):
     assume(serialized != perturbed)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-opaque-keys',
-    version='0.4',
+    version='0.4.1',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[


### PR DESCRIPTION
Cut down on the number of deprecation warnings generated, by avoiding usage of deprecated properties where feasible.

Also fixed a failure case uncovered by Hypothesis, where slashes were being allowed (and ignored) at the end of usage keys using the deprecated serialization format.  Cale thinks it's highly unlikely that any such strings made it through our existing parser into production data.

Finally, disabled a Hypothesis health check for slow data generation, which seems to be routinely triggered now for our existing Travis configuration.