### PR TITLE
PLAT-2066 Remove pytest-django from extras_require

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,8 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
-.cache
+.cache/
+.pytest_cache/
 nosetests.xml
 coverage.xml
 .python-version

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,20 @@
 # Unreleased
 
+# 0.4.4
+
+* Remove pytest-django as a dependency of the optional Django support; it's
+  only needed for testing, not normal usage
+
+# 0.4.3
+
+* Remove the accidentally included "settings" package from the distribution
+
+# 0.4.2
+
+* Added OpaqueKeyField and its subclasses, extracted from edx-platform
+* Added the "django" installation option to indicate the optional dependency
+  on the Django package
+
 # 0.4.1
 
 * Stop an assortment of deprecation warnings by replacing internal usage of

--- a/requirements-with-django.txt
+++ b/requirements-with-django.txt
@@ -1,2 +1,3 @@
 -e .[django]
 -r test-requirements.txt
+pytest-django

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-opaque-keys',
-    version='0.4.3',
+    version='0.4.4',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[
@@ -20,7 +20,7 @@ setup(
         'pymongo>=2.7.2,<4.0.0'
     ],
     extras_require={
-        'django': ['Django>=1.8,<2.0', 'pytest-django==3.1.2']
+        'django': ['Django>=1.8,<2.0']
     },
     entry_points={
         'opaque_keys.testing': [


### PR DESCRIPTION
Move pytest-django to the testing requirements.  Also added missing changelog entries and added a .gitignore entry for the new pytest cache directory name.