### PR TITLE
Proposed usability improvements for django key fields

### DIFF
--- a/opaque_keys/edx/django/tests/models.py
+++ b/opaque_keys/edx/django/tests/models.py
@@ -64,6 +64,6 @@ class ComplexModel(Model):
     """A Django Model for testing Course/Usage/Location/BlockType Key fields."""
 
     id = CharField(primary_key=True, max_length=255)  # pylint: disable=invalid-name
-    course_key = CourseKeyField(max_length=255, validators=[is_edx])
-    block_type_key = BlockTypeKeyField(max_length=255, blank=True)
-    usage_key = UsageKeyField(max_length=255, blank=False)
+    course_key = CourseKeyField(validators=[is_edx])
+    block_type_key = BlockTypeKeyField(blank=True)
+    usage_key = UsageKeyField(blank=False)

--- a/opaque_keys/edx/django/tests/test_models.py
+++ b/opaque_keys/edx/django/tests/test_models.py
@@ -90,6 +90,15 @@ class TestKeyFieldImplementation(TestCase):
         fetched = ComplexModel.objects.filter(course_key=self.course_key).first()
         self.assertEqual(fetched, self.model)
 
+    def test_fetch_from_usage_key_course_lookup(self):
+        # Expect a match:
+        fetched = ComplexModel.objects.filter(usage_key__course=self.course_key).first()
+        self.assertEqual(fetched, self.model)
+        # Expect no match:
+        other_course_key = CourseKey.from_string('course-v1:NOTedX+FUN101x+3T2017')
+        other_fetched = ComplexModel.objects.filter(usage_key__course=other_course_key).first()
+        self.assertIsNone(other_fetched)
+
     def test_validation_no_errors(self):
         self.model.clean_fields()
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,16 +6,16 @@ skipsdist = True
 [testenv]
 deps =
     -r{toxinidir}/requirements.txt
-commands = py.test --ignore=opaque_keys/edx/django {posargs}
+commands = py.test --disable-pytest-warnings --ignore=opaque_keys/edx/django {posargs}
 
 [testenv:django18]
 deps =
     django>=1.8,<1.9
     -r{toxinidir}/requirements-with-django.txt
-commands = py.test --nomigrations {posargs}
+commands = py.test --disable-pytest-warnings --nomigrations {posargs}
 
 [testenv:django111]
 deps =
     django>=1.11,<2.0
     -r{toxinidir}/requirements-with-django.txt
-commands = py.test --nomigrations {posargs}
+commands = py.test --disable-pytest-warnings --nomigrations {posargs}


### PR DESCRIPTION
Two proposed changes to make `UsageKeyField` and friends more useful:

1. Give each of `UsageKeyField` and friends a sensible `max_length` default to DRY up model definitions. Currently we put `max_length=255` in every single model definition where these are used. In addition, use a shorter default length which is compatible with InnoDB indexing when the `utf8mb4` character set is used regardless of the MySQL index length configuration. IMHO any new IDAs we make should be using `utf8mb4` for their entire DB, so the default length should be compatible.
1. It's currently a common pattern to have both a `course_id` field and a `usage_id` field in order to get indexed lookups by course. However, for almost four years we've been using usage keys which have the course ID at the beginning of the serialized usage key value, so it's possible to use only a single indexed `usage_id` column and still query by course using `WHERE usage_key LIKE 'block-v1:COURSE_ID_HERE%'` just as efficiently as if course_id was materialized in its own column and index. With this change, you can create a model that only has a usage_id field and then query by course using the `Model.objects.filter(usage_key__course=self.course_key)` lookup.

Tradeoffs of #2 are:
* Simplifies data model
* Reduces table/index size somewhat by removing redundant data
* Improves data integrity (derived course_id will always correspond to usage_id) - we have observed such a column mismatch bug in the wild on at least one occasion
* But it doesn't support old mongo keys
* It places the constraint on new UsageKey formats that they must encode the course ID in the usage key serialized form in order to be compatible.
* Doesn't support `usage_id__course__in=[list of course IDs]` though that could be added later.
* Prevents `GROUP BY course_id` clauses

**Manual testing**:
Install in your LMS devstack container, then run something like the following from the LMS django shell:

```python
from courseware.models import StudentModule
obj = StudentModule.objects.all()[10]
course_key = obj.course_id
StudentModule.objects.filter(module_state_key__course=course_key)
```