### PR TITLE
Parse value from string to prepare django ORM query.

### DIFF
--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -129,6 +129,9 @@ class OpaqueKeyField(CreatorMixin, CharField):
         if value is self.Empty or value is None:
             return ''  # CharFields should use '' as their empty value, rather than None
 
+        if isinstance(value, six.string_types):
+            value = self.KEY_CLASS.from_string(value)
+
         assert isinstance(value, self.KEY_CLASS), "%s is not an instance of %s" % (value, self.KEY_CLASS)
         serialized_key = six.text_type(_strip_value(value))
         if serialized_key.endswith('\n'):

--- a/opaque_keys/edx/django/tests/test_models.py
+++ b/opaque_keys/edx/django/tests/test_models.py
@@ -90,6 +90,10 @@ class TestKeyFieldImplementation(TestCase):
         fetched = ComplexModel.objects.filter(course_key=self.course_key).first()
         self.assertEqual(fetched, self.model)
 
+    def test_fetch_from_db_with_str(self):
+        fetched = ComplexModel.objects.filter(course_key=six.text_type(self.course_key)).first()
+        self.assertEqual(fetched, self.model)
+
     def test_validation_no_errors(self):
         self.model.clean_fields()
 


### PR DESCRIPTION
Different modules use an Opaque key subclass [as unique id](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/content/course_overviews/models.py#L55). And, the opaque key field class is implemented in a way that you have to pass an instance of whatever the `KEY_CLASS` is for lookup. Meaning, one cannot do `co = CourseOverview.objects.get(id='some-course-overview-key')` but instead one has to retrieve a `CourseKey` instance and use that as the id value.
This PR changes this so the `KEY_CLASS` lookup is done if a string is used for the ORM query, making it easier to write queries and also making it easier to use admin forms that involve opaque keys subclass fields.
The reason why this makes it easier to use admin forms is because django admin will automatically handle populating the form and saving it. But since django will only send the values from the `POST` request this fails since the opaque key subclass is not receiving a `KEY_CLASS` for the query. Because of this issue when preparing the ORM query we see ourselves forced to do [some unnecessary transformation of the request data ](https://github.com/edx/edx-platform/pull/17254/files).

**JIRA tickets**: With this PR we're trying to avoid the solution proposed in this ticket: https://openedx.atlassian.net/browse/LEARNER-3672

**Discussions**: The previous solution is discussed here: https://github.com/edx/edx-platform/pull/17254

**Screenshots**: N/A

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

Manual testing:

1. Run local devstack.
2. Install this branch (`pip install -e`).
3. Drop into a django shell.
4. Retrieve a course using a string:
```python
>>> from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
>>> CourseOverview.objects.get(id='course-v1:Microsoft+T9C3+1T2018')
```

**Author notes and concerns**:

1. We are aware that there's probably a need to write a few new tests on `edx:edx-platform` to account for this change. We have added a  unit test to check retrieving a model that uses `OpaqueKey` field with a string.

**Reviewers**
- [x] @Agrendalath (Piotr)
- [x] edX reviewer[s] TBD