### PR TITLE
Account for change in hypothesis library

### DIFF
--- a/opaque_keys/edx/tests/test_properties.py
+++ b/opaque_keys/edx/tests/test_properties.py
@@ -5,7 +5,7 @@ installed keys should have.
 
 import logging
 
-from hypothesis import strategies, given, assume, example
+from hypothesis import strategies, _strategies, given, assume, example
 from six import text_type
 from six.moves import range  # pylint: disable=redefined-builtin
 from opaque_keys.edx.keys import CourseKey, UsageKey, DefinitionKey, BlockTypeKey, AssetKey
@@ -116,7 +116,7 @@ def perturbed_by_subsection(draw, string_strategy):
     return output_string
 
 
-@strategies.cacheable
+@_strategies.cacheable
 def perturbed_strings(string_strategy):
     """
     A strategy that constructs a string using the supplied ``string_strategy``,

--- a/opaque_keys/tests/strategies.py
+++ b/opaque_keys/tests/strategies.py
@@ -6,7 +6,7 @@ from functools import update_wrapper
 import string
 from six import text_type
 
-from hypothesis import strategies, assume
+from hypothesis import strategies, _strategies, assume
 from singledispatch import singledispatch
 
 from opaque_keys.edx.block_types import BlockTypeKeyV1, XBLOCK_V1, XMODULE_V1
@@ -29,7 +29,7 @@ from opaque_keys.edx.locator import (
 )
 
 
-@strategies.cacheable
+@_strategies.cacheable
 def unicode_letters_and_digits():
     """
     Strategy to return unicode characters and numbers.
@@ -47,7 +47,7 @@ def unicode_letters_and_digits():
     )
 
 
-@strategies.cacheable
+@_strategies.cacheable
 def allowed_locator_ids():
     """
     Strategy to generate valid ids for Locator fields.
@@ -58,7 +58,7 @@ def allowed_locator_ids():
     )
 
 
-@strategies.cacheable
+@_strategies.cacheable
 def deprecated_locator_ids():
     """
     Strategy to generate valid ids for deprecated Locator fields.
@@ -69,7 +69,7 @@ def deprecated_locator_ids():
     )
 
 
-@strategies.cacheable
+@_strategies.cacheable
 def deprecated_course_ids():
     """
     Strategy to generate valid ids for deprecated CourseLocator fields.
@@ -80,7 +80,7 @@ def deprecated_course_ids():
     )
 
 
-@strategies.cacheable
+@_strategies.cacheable
 def version_guids():
     """
     Strategy to generate valid ObjectIds.
@@ -107,7 +107,7 @@ def classdispatch(func):
 
 
 @classdispatch
-@strategies.cacheable
+@_strategies.cacheable
 def fields_for_key(cls, field):  # pylint: disable=unused-argument
     """
     A ``hypothesis`` strategy to generate data of the right type for the fields of this OpaqueKey.
@@ -136,7 +136,7 @@ def _aside_v1_exclusions(draw, strategy):
 
 
 @fields_for_key.register(AsideDefinitionKeyV1)
-@strategies.cacheable
+@_strategies.cacheable
 def _fields_for_aside_def_key_v1(cls, field):  # pylint: disable=missing-docstring
     if field == 'deprecated':
         return strategies.just(False)
@@ -149,7 +149,7 @@ def _fields_for_aside_def_key_v1(cls, field):  # pylint: disable=missing-docstri
 
 
 @fields_for_key.register(AsideUsageKeyV1)
-@strategies.cacheable
+@_strategies.cacheable
 def _fields_for_aside_usage_key_v1(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'deprecated':
         return strategies.just(False)
@@ -162,7 +162,7 @@ def _fields_for_aside_usage_key_v1(cls, field):  # pylint: disable=missing-docst
 
 
 @fields_for_key.register(AsideDefinitionKeyV2)
-@strategies.cacheable
+@_strategies.cacheable
 def _fields_for_aside_def_key_v2(cls, field):  # pylint: disable=missing-docstring
     if field == 'deprecated':
         return strategies.just(False)
@@ -173,7 +173,7 @@ def _fields_for_aside_def_key_v2(cls, field):  # pylint: disable=missing-docstri
 
 
 @fields_for_key.register(AsideUsageKeyV2)
-@strategies.cacheable
+@_strategies.cacheable
 def _fields_for_aside_usage_key_v2(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'deprecated':
         return strategies.just(False)
@@ -184,7 +184,7 @@ def _fields_for_aside_usage_key_v2(cls, field):  # pylint: disable=missing-docst
 
 
 @fields_for_key.register(LibraryLocator)
-@strategies.cacheable
+@_strategies.cacheable
 def _fields_for_library_locator(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'version_guid':
         return version_guids()
@@ -197,7 +197,7 @@ def _fields_for_library_locator(cls, field):  # pylint: disable=missing-docstrin
 
 
 @fields_for_key.register(DefinitionLocator)
-@strategies.cacheable
+@_strategies.cacheable
 def _fields_for_definition_locator(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'definition_id':
         return version_guids()
@@ -208,7 +208,7 @@ def _fields_for_definition_locator(cls, field):  # pylint: disable=missing-docst
 
 
 @classdispatch
-@strategies.cacheable
+@_strategies.cacheable
 def instances_of_key(cls, **kwargs):
     """
     A ``hypothesis`` strategy to generate instances of this OpaqueKey class.
@@ -228,7 +228,7 @@ def instances_of_key(cls, **kwargs):
 
 
 @instances_of_key.register(BlockTypeKeyV1)
-@strategies.cacheable
+@_strategies.cacheable
 def _instances_of_block_type_key(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
 
     return strategies.builds(
@@ -244,7 +244,7 @@ def _instances_of_block_type_key(cls, **kwargs):  # pylint: disable=missing-docs
 
 
 @instances_of_key.register(CourseLocator)
-@strategies.cacheable
+@_strategies.cacheable
 def _instances_of_course_locator(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
 
     return strategies.builds(
@@ -266,7 +266,7 @@ def _instances_of_course_locator(cls, **kwargs):  # pylint: disable=missing-docs
 
 
 @instances_of_key.register(BlockUsageLocator)
-@strategies.cacheable
+@_strategies.cacheable
 def _instances_of_block_usage(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
 
     def locator_for_course(course_key):
@@ -295,7 +295,7 @@ def _instances_of_block_usage(cls, **kwargs):  # pylint: disable=missing-docstri
 
 
 @instances_of_key.register(LibraryUsageLocator)
-@strategies.cacheable
+@_strategies.cacheable
 def _instances_of_library_usage(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
 
     return strategies.builds(
@@ -307,7 +307,7 @@ def _instances_of_library_usage(cls, **kwargs):  # pylint: disable=missing-docst
 
 
 @instances_of_key.register(DeprecatedLocation)
-@strategies.cacheable
+@_strategies.cacheable
 def _instances_of_deprecated_loc(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
 
     return strategies.builds(
@@ -323,7 +323,7 @@ def _instances_of_deprecated_loc(cls, **kwargs):  # pylint: disable=missing-docs
 
 
 @classdispatch
-@strategies.cacheable
+@_strategies.cacheable
 def keys_of_type(cls, blacklist=None):
     """
     A ``hypothesis`` strategy to generate instances of this OpaqueKey KeyType.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 coverage
 ddt
 edx-lint==0.4.0
-hypothesis >= 3.6.0
+hypothesis >= 3.84.5
 mock
 nose
 pep8

--- a/tox.ini
+++ b/tox.ini
@@ -6,16 +6,16 @@ skipsdist = True
 [testenv]
 deps =
     -r{toxinidir}/requirements.txt
-commands = py.test --ignore=opaque_keys/edx/django {posargs}
+commands = py.test --disable-pytest-warnings --ignore=opaque_keys/edx/django {posargs}
 
 [testenv:django18]
 deps =
     django>=1.8,<1.9
     -r{toxinidir}/requirements-with-django.txt
-commands = py.test --nomigrations {posargs}
+commands = py.test --disable-pytest-warnings --nomigrations {posargs}
 
 [testenv:django111]
 deps =
     django>=1.11,<2.0
     -r{toxinidir}/requirements-with-django.txt
-commands = py.test --nomigrations {posargs}
+commands = py.test --disable-pytest-warnings --nomigrations {posargs}


### PR DESCRIPTION
Tests were failing with the following stacktrace:

```
__________ ERROR collecting opaque_keys/edx/tests/test_properties.py ___________
opaque_keys/edx/tests/test_properties.py:13: in <module>
    from opaque_keys.tests.strategies import keys_of_type
opaque_keys/tests/strategies.py:32: in <module>
    @strategies.cacheable
E   AttributeError: 'module' object has no attribute 'cacheable'
__________ ERROR collecting opaque_keys/edx/tests/test_properties.py ___________
opaque_keys/edx/tests/test_properties.py:13: in <module>
    from opaque_keys.tests.strategies import keys_of_type
opaque_keys/tests/strategies.py:32: in <module>
    @strategies.cacheable
E   AttributeError: 'module' object has no attribute 'cacheable'
=================================== FAILURES ===================================
______________ [pylint] opaque_keys/edx/tests/test_properties.py _______________
[gw0] linux2 -- Python 2.7.6 /home/travis/build/edx/opaque-keys/.tox/py27/bin/python
E:119, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
___________________ [pylint] opaque_keys/tests/strategies.py ___________________
[gw1] linux2 -- Python 2.7.6 /home/travis/build/edx/opaque-keys/.tox/py27/bin/python
E: 32, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E: 50, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E: 61, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E: 72, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E: 83, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:110, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:139, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:152, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:165, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:176, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:187, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:200, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:211, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:231, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:247, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:269, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:298, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:310, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
E:326, 1: Module 'hypothesis.strategies' has no 'cacheable' member (no-member)
```

This was introduced by this change in the hypothesis library: https://github.com/HypothesisWorks/hypothesis/pull/1703 and included in the 3.84.5 release, so I bumped that dependency accordingly too.

Also, my initial attempt to run travis resulted in a failure from a log size that was too large. I noticed this PR had experienced the same thing but solved it with the pytest supression: https://github.com/edx/opaque-keys/pull/100