### PR TITLE
Drop to_dreprecated_string and from_deprecated_string

### DIFF
--- a/opaque_keys/edx/locations.py
+++ b/opaque_keys/edx/locations.py
@@ -39,16 +39,6 @@ class SlashSeparatedCourseKey(CourseLocator):
         super(SlashSeparatedCourseKey, self).__init__(org, course, run, deprecated=True, **kwargs)
 
     @classmethod
-    def from_deprecated_string(cls, serialized):
-        """Deprecated. Use :class:`locator.CourseLocator.from_string`"""
-        warnings.warn(
-            "SlashSeparatedCourseKey is deprecated! Please use locator.CourseLocator",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        return CourseLocator.from_string(serialized)
-
-    @classmethod
     def from_string(cls, serialized):
         """Deprecated. Use :meth:`locator.CourseLocator.from_string`."""
         warnings.warn(
@@ -159,12 +149,6 @@ class LocationBase(object):
             deprecated=True
         ))
         super(LocationBase, self).__init__(course_key, category, name, deprecated=True, **kwargs)
-
-    @classmethod
-    def from_deprecated_string(cls, serialized):
-        """Deprecated. Use :meth:`locator.BlockUsageLocator.from_string`."""
-        cls._deprecation_warning()
-        return BlockUsageLocator.from_string(serialized)
 
     @classmethod
     def from_string(cls, serialized):
@@ -283,7 +267,3 @@ class AssetLocation(LocationBase, AssetLocator):
         """Deprecated. See BlockUsageLocator._from_deprecated_son"""
         cls._deprecation_warning()
         return AssetLocator._from_deprecated_son(id_dict, run)
-
-    @classmethod
-    def from_deprecated_string(cls, serialized):
-        return cls._from_deprecated_string(serialized)

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -349,15 +349,6 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
         """Returns an 'old-style' course id, represented as 'org/course/run'"""
         return u'/'.join([self.org, self.course, self.run])
 
-    def to_deprecated_string(self):
-        """Deprecated. Use unicode(key) instead."""
-        warnings.warn(
-            "to_deprecated_string is deprecated! Use unicode(key) instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        return text_type(self)
-
     @classmethod
     def _from_deprecated_string(cls, serialized):
         """
@@ -954,15 +945,6 @@ class BlockUsageLocator(BlockLocatorBase, UsageKey):
             url += u"@{rev}".format(rev=self.course_key.branch)
         return url
 
-    def to_deprecated_string(self):
-        """Deprecated. Use unicode(key) instead."""
-        warnings.warn(
-            "to_deprecated_string is deprecated! Use unicode(key) instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        return text_type(self)
-
     @classmethod
     def _from_deprecated_string(cls, serialized):
         """
@@ -1292,15 +1274,6 @@ class AssetLocator(BlockUsageLocator, AssetKey):    # pylint: disable=abstract-m
         if self.course_key.branch:
             url += u'@{}'.format(self.course_key.branch)
         return url
-
-    def to_deprecated_string(self):
-        """Deprecated. Use unicode(key) instead."""
-        warnings.warn(
-            "to_deprecated_string is deprecated! Use unicode(key) instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        return text_type(self)
 
     @property
     def tag(self):

--- a/opaque_keys/edx/tests/test_course_locators.py
+++ b/opaque_keys/edx/tests/test_course_locators.py
@@ -265,10 +265,10 @@ class TestCourseKeys(LocatorBaseTest, TestDeprecated):
     )
     def test_make_usage_key_from_deprecated_string_roundtrip(self, url):
         course_key = CourseLocator('org', 'course', 'run')
-        with self.assertDeprecationWarning(count=2):
+        with self.assertDeprecationWarning(count=1):
             self.assertEqual(
                 url,
-                course_key.make_usage_key_from_deprecated_string(url).to_deprecated_string()
+                text_type(course_key.make_usage_key_from_deprecated_string(url))
             )
 
     def test_empty_run(self):

--- a/opaque_keys/edx/tests/test_deprecated_locations.py
+++ b/opaque_keys/edx/tests/test_deprecated_locations.py
@@ -51,7 +51,7 @@ class TestSSCK(TestDeprecated):
 
     def test_deprecated_from_dep_string(self):
         with self.assertDeprecationWarning():
-            ssck = SlashSeparatedCourseKey.from_deprecated_string("foo/bar/baz")
+            ssck = SlashSeparatedCourseKey.from_string("foo/bar/baz")
         self.assertTrue(isinstance(ssck, CourseLocator))
 
     def test_deprecated_from_dep_string_bad(self):


### PR DESCRIPTION
These are old deprecated methods (with replacements 'unicode' and
'from_string' respectively). We don't believe any other code in
the Open edX platform is using them anymore.

DEPR-16