### PR TITLE
Bump version to 1.0.0 and add a changelog entry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,12 @@
 # Unreleased
 
+# 1.0.0
+
+* Remove to_deprecated_string and from_deprecated_string API methods
+* Support OpaqueKeyField lookups by string
+* Support more recent versions of the hypothesis Python module
+* Support Python 3.6 instead of 3.5
+
 # 0.4.4
 
 * Remove pytest-django as a dependency of the optional Django support; it's

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-opaque-keys',
-    version='0.4.4',
+    version='1.0.0',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[


### PR DESCRIPTION
Normally I wouldn't bother with a full review, but since this is going from 0.x to 1.0, it feels momentous enough to check in.

The major version bump is because of DEPR-16 and us removing the to_deprecated_string and from_deprecated_string API.