### PR TITLE
Add New Blockstore-related Opaque Key Types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,17 @@
 # Unreleased
 
+
+# 2.0
+
+* Added LibraryLocatorV2 and LibraryUsageLocatorV2
+* Added LearningContextKey, UsageKeyV2, and BundleDefinitionLocator
+* Added the .is_course helper method
+
+# 1.0.1
+
+* Included test code in the PyPI package so its mixins can be imported into
+  other code
+
 # 1.0.0
 
 * Remove to_deprecated_string and from_deprecated_string API methods

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -17,7 +17,7 @@ except ImportError:  # pragma: no cover
 
 import six
 
-from opaque_keys.edx.keys import BlockTypeKey, CourseKey, UsageKey
+from opaque_keys.edx.keys import BlockTypeKey, CourseKey, LearningContextKey, UsageKey
 
 
 log = logging.getLogger(__name__)
@@ -176,6 +176,19 @@ try:
 except AttributeError:
     #  Django was not imported
     pass
+
+
+class LearningContextKeyField(OpaqueKeyField):
+    """
+    A django Field that stores a LearningContextKey object as a string.
+
+    If you know for certain that your code will only deal with courses, use
+    CourseKeyField instead, but if you are writing something more generic that
+    could apply to any learning context (libraries, etc.), use this instead of
+    CourseKeyField.
+    """
+    description = "A LearningContextKey object, saved to the DB in the form of a string"
+    KEY_CLASS = LearningContextKey
 
 
 class CourseKeyField(OpaqueKeyField):

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -4,17 +4,47 @@ OpaqueKey abstract classes for edx-platform object types (courses, definitions, 
 """
 import json
 from abc import abstractmethod, abstractproperty
+import warnings
 from six import text_type
 
 from opaque_keys import OpaqueKey
 
 
-class CourseKey(OpaqueKey):
+class LearningContextKey(OpaqueKey):
+    """
+    An :class:`opaque_keys.OpaqueKey` identifying a course, a library, a
+    program, a website, or some other collection of content where learning
+    happens.
+
+    This concept is more generic than "course."
+
+    A learning context does not necessarily have an org, course, or, run.
+    """
+    KEY_TYPE = 'context_key'
+    __slots__ = ()
+
+    # is_course: subclasses should override this to indicate whether or not this
+    # key type represents a course (as opposed to a library or something else).
+    # We can't just use isinstance(key, CourseKey) because LibraryLocators
+    # are subclasses of CourseKey for historical reasons. Once modulestore-
+    # based content libraries are removed, one can replace this with
+    # just isinstance(key, CourseKey)
+    is_course = False
+
+    def make_definition_usage(self, definition_key, usage_id=None):
+        """
+        Return a usage key, given the given the specified definition key and
+        usage_id.
+        """
+        raise NotImplementedError()
+
+
+class CourseKey(LearningContextKey):
     """
     An :class:`opaque_keys.OpaqueKey` identifying a particular Course object.
     """
-    KEY_TYPE = 'course_key'
     __slots__ = ()
+    is_course = True
 
     @abstractproperty
     def org(self):  # pragma: no cover
@@ -156,6 +186,66 @@ class UsageKey(CourseObjectMixin, OpaqueKey):
         The name of this usage.
         """
         raise NotImplementedError()
+
+    @property
+    def context_key(self):
+        """
+        Get the learning context key (LearningContextKey) for this XBlock usage.
+        """
+        return self.course_key
+
+
+class UsageKeyV2(UsageKey):
+    """
+    An :class:`opaque_keys.OpaqueKey` identifying an XBlock used in a specific
+    learning context (e.g. a course).
+
+    Definition + Learning Context = Usage
+
+    UsageKeyV2 is just a subclass of UsageKey with slightly different behavior,
+    but not a distinct key type (same KEY_TYPE). UsageKeyV2 should be used for
+    new usage key types; the main differences between it and UsageKey are:
+        * the .course_key property is considered deprecated for the new V2 key
+          types, and they should implement .context_key instead.
+        * the .definition_key property is explicitly disabled for V2 usage keys
+    """
+    __slots__ = ()
+
+    @abstractproperty
+    def context_key(self):
+        """
+        Get the learning context key (LearningContextKey) for this XBlock usage.
+        May be a course key, library key, or some other LearningContextKey type.
+        """
+        raise NotImplementedError()
+
+    @property
+    def definition_key(self):
+        """
+        Returns the definition key for this usage. For the newer V2 key types,
+        this cannot be done with the key alone, so it's necessary to ask the
+        key's learning context to provide the underlying definition key.
+        """
+        raise AttributeError(
+            "Version 2 usage keys do not support direct .definition_key access. "
+            "To get the definition key within edxapp, use: "
+            "get_learning_context_impl(usage_key).definition_for_usage(usage_key)"
+        )
+
+    @property
+    def course_key(self):
+        warnings.warn("Use .context_key instead of .course_key", DeprecationWarning, stacklevel=2)
+        return self.context_key
+
+    def map_into_course(self, course_key):
+        """
+        Implement map_into_course for API compatibility. Shouldn't be used in
+        new code.
+        """
+        if course_key == self.context_key:
+            return self
+        else:
+            raise ValueError("Cannot use map_into_course like that with this key type.")
 
 
 class AsideDefinitionKey(DefinitionKey):

--- a/opaque_keys/edx/tests/test_default_deprecated.py
+++ b/opaque_keys/edx/tests/test_default_deprecated.py
@@ -2,7 +2,7 @@
 Test that old keys deserialize just by importing opaque keys
 """
 from unittest import TestCase
-from opaque_keys.edx.keys import CourseKey, UsageKey
+from opaque_keys.edx.keys import CourseKey, LearningContextKey, UsageKey
 
 
 class TestDefault(TestCase):
@@ -18,6 +18,18 @@ class TestDefault(TestCase):
 
         key = CourseKey.from_string('course-v1:org.id+course_id+run')
         self.assertEqual(key.org, 'org.id')
+
+    def test_learning_context_key(self):
+        """
+        Test CourseKey
+        """
+        key = LearningContextKey.from_string('org.id/course_id/run')
+        self.assertEqual(key.org, 'org.id')
+        self.assertIsInstance(key, CourseKey)
+
+        key = LearningContextKey.from_string('course-v1:org.id+course_id+run')
+        self.assertEqual(key.org, 'org.id')
+        self.assertIsInstance(key, CourseKey)
 
     def test_usage_key(self):
         """

--- a/opaque_keys/edx/tests/test_is_course.py
+++ b/opaque_keys/edx/tests/test_is_course.py
@@ -1,0 +1,23 @@
+"""
+Test that the .is_course helper property does what it's supposed to
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+from unittest import TestCase
+
+from opaque_keys.edx.locator import CourseLocator, LibraryLocator, LibraryLocatorV2
+
+
+class IsCourseTests(TestCase):
+    """
+    Test the .is_course property.
+
+    This is because for historical reasons, isinstance(key, CourseKey) will
+    sometimes return a library key (modulestore split mongo content libraries).
+    """
+    def test_is_course(self):
+        course_key = CourseLocator("SchoolX", "course1", "2020")
+        self.assertEqual(course_key.is_course, True)
+        lib_key = LibraryLocator("SchoolX", "lib1")
+        self.assertEqual(lib_key.is_course, False)
+        lib2_key = LibraryLocatorV2("SchoolX", "lib-slug")
+        self.assertEqual(lib2_key.is_course, False)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-opaque-keys',
-    version='1.0.1',
+    version='2.0.0',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[
@@ -31,15 +31,17 @@ setup(
             'hex = opaque_keys.tests.test_opaque_keys:HexKey',
             'dict = opaque_keys.tests.test_opaque_keys:DictKey',
         ],
-        'course_key': [
+        'context_key': [
             'course-v1 = opaque_keys.edx.locator:CourseLocator',
             'library-v1 = opaque_keys.edx.locator:LibraryLocator',
+            'lib = opaque_keys.edx.locator:LibraryLocatorV2',
             # don't use slashes in any new code
             'slashes = opaque_keys.edx.locator:CourseLocator',
         ],
         'usage_key': [
             'block-v1 = opaque_keys.edx.locator:BlockUsageLocator',
             'lib-block-v1 = opaque_keys.edx.locator:LibraryUsageLocator',
+            'lb = opaque_keys.edx.locator:LibraryUsageLocatorV2',
             'location = opaque_keys.edx.locations:DeprecatedLocation',
             'aside-usage-v1 = opaque_keys.edx.asides:AsideUsageKeyV1',
             'aside-usage-v2 = opaque_keys.edx.asides:AsideUsageKeyV2',
@@ -51,6 +53,7 @@ setup(
             'def-v1 = opaque_keys.edx.locator:DefinitionLocator',
             'aside-def-v1 = opaque_keys.edx.asides:AsideDefinitionKeyV1',
             'aside-def-v2 = opaque_keys.edx.asides:AsideDefinitionKeyV2',
+            'bundle-olx = opaque_keys.edx.locator:BundleDefinitionLocator',
         ],
         'block_type': [
             'block-type-v1 = opaque_keys.edx.block_types:BlockTypeKeyV1',


### PR DESCRIPTION
This PR moves some key-related code for new Blockstore-based content out of `edx-platform` and into `opaque-keys`.

It includes: 
* A new abstract key type, `LearningContextKey`, which identifies a _learning context_. A learning context may be a course, a library, or other types in the future.
    - All `CourseKey`s are `LearningContextKey`s
* A new `LibraryLocatorV2` key type which is a type of `LearningContextKey` that identifies a Blockstore-based content library.
    - Note that unlike the existing modulestore-based [`LibraryLocator`](https://github.com/edx/opaque-keys/blob/72e54d1d40aa8209f3eef5238f64794f5804895f/opaque_keys/edx/locator.py#L378), calling `isinstance(LibraryLocatorV2, Coursekey)` will return `False` because we now have this more abstract type to use. Yay.
* A new `LibraryUsageLocatorV2` key type which identifies a usage of an XBlock in a Blockstore-based content library.
* A new concrete `DefinitionKey` type, `BundleDefinitionLocator`. These keys are mostly used internally in the new Blockstore-based XBlock runtime. Any XBlock in Blockstore will have one of these keys as its `.scope_ids.def_id` value. A `BundleDefinitionLocator` specifies a specific XBlock in a specific OLX file in a specific version (or draft) of a specific Blockstore bundle.

## Implications for developers

This PR has one change that affects existing code: it changes the `KEY_TYPE` of `CourseKey` and `CourseLocator` to `context_key`. Which impacts `ccx-keys` and requires a corresponding change there: https://github.com/edx/ccx-keys/pull/8  . Both that change and this must be brought into edx-platform at the same time, or some CCX-related tests will fail.

Also, as we roll out and use more of the new content library code in the platform, it will be the case that other parts of the LMS and related apps may start seeing XBlock UsageKeys that refer to Blockstore-based content libraries. (So far the new runtime is completely isolated but coming PRs will change that.) The `.context_key` property of any usage key will return the `LearningContextKey` (usually a CourseKey). But, importantly, so will the `.course_key` property, which may produce unexpected results if the code in question doesn't know what do to with a non-course key.

Because the old `LibraryLocator` classes inherit from `CourseKey`, dealing with all this could get a little messy, so I've added a nice `.is_course` property to all `LearningContextKey` types that will always give you the correct answer. So there are now two recommended patterns for reading usage keys if your code only knows how to deal with courses:

If your code should work with any course, but you don't want to deal with libraries or other things:
```
from opaque_keys.edx.keys import UsageKey
usage_key = UsageKey.from_string(...whatever...)
if not usage_key.context_key.is_course:
    return  # Ignore this entry if this code only knows how to deal with courses. It could be a modulestore-based content library or blockstore-based content library, or some new thing
# proceed with processing usage_key
```

If your code is pretty specific to modulestore-based courses and you think it might break with future Blockstore-based courses:
```
from opaque_keys.edx.keys import UsageKey
from opaque_keys.edx.locator import CourseLocator
usage_key = UsageKey.from_string(...whatever...)
if not isinstance(usage_key.context_key, CourseLocator):
    return  # Ignore anything that's not a modulestore course
# proceed with processing usage_key
```

Same goes if you have a generic `context_key` or `course_key`: you should use either `context_key.is_course` or `isinstance(course_key, CourseLocator)` (depending on if your code is modulestore-specific or not) and ignore the key when these return `False`.

Likewise when parsing a key, use `LearningContextKey.from_string(...)` if you don't care if it's a course or not, and use `CourseKey.from_string(...)` if you expected a course. In either case, wrap that in a `try: ... except InvalidKeyError: ...` so you can handle unexpected key types gracefully.