### PR TITLE
Fix `make upgrade` by bumping pip-tools version; run upgrades

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,7 @@
 import os
 from hypothesis import settings, Verbosity
 
-settings.register_profile("ci", settings(max_examples=10000))
+settings.register_profile("ci", settings(max_examples=2000))
 settings.register_profile("dev", settings(max_examples=100))
 settings.register_profile("debug", settings(max_examples=10, verbosity=Verbosity.verbose))
 

--- a/opaque_keys/edx/tests/test_properties.py
+++ b/opaque_keys/edx/tests/test_properties.py
@@ -5,7 +5,8 @@ installed keys should have.
 
 import logging
 
-from hypothesis import strategies, _strategies, given, assume, example, HealthCheck, settings
+from hypothesis import strategies, given, assume, example, HealthCheck, settings
+from hypothesis.strategies._internal.core import cacheable
 from six import text_type
 from six.moves import range  # pylint: disable=redefined-builtin
 from opaque_keys.edx.keys import CourseKey, UsageKey, DefinitionKey, BlockTypeKey, AssetKey
@@ -116,7 +117,7 @@ def perturbed_by_subsection(draw, string_strategy):
     return output_string
 
 
-@_strategies.cacheable
+@cacheable
 def perturbed_strings(string_strategy):
     """
     A strategy that constructs a string using the supplied ``string_strategy``,

--- a/opaque_keys/tests/strategies.py
+++ b/opaque_keys/tests/strategies.py
@@ -6,7 +6,8 @@ from functools import update_wrapper
 import string
 from six import text_type
 
-from hypothesis import strategies, _strategies, assume
+from hypothesis import strategies, assume
+from hypothesis.strategies._internal.core import cacheable
 from singledispatch import singledispatch
 
 from opaque_keys.edx.block_types import BlockTypeKeyV1, XBLOCK_V1, XMODULE_V1
@@ -32,7 +33,7 @@ from opaque_keys.edx.locator import (
 )
 
 
-@_strategies.cacheable
+@cacheable
 def unicode_letters_and_digits():
     """
     Strategy to return unicode characters and numbers.
@@ -50,7 +51,7 @@ def unicode_letters_and_digits():
     )
 
 
-@_strategies.cacheable
+@cacheable
 def ascii_identifier():
     """
     Strategy to generate a slug with no unicode
@@ -62,7 +63,7 @@ def ascii_identifier():
     )
 
 
-@_strategies.cacheable
+@cacheable
 def allowed_locator_ids():
     """
     Strategy to generate valid ids for Locator fields.
@@ -73,7 +74,7 @@ def allowed_locator_ids():
     )
 
 
-@_strategies.cacheable
+@cacheable
 def deprecated_locator_ids():
     """
     Strategy to generate valid ids for deprecated Locator fields.
@@ -84,7 +85,7 @@ def deprecated_locator_ids():
     )
 
 
-@_strategies.cacheable
+@cacheable
 def deprecated_course_ids():
     """
     Strategy to generate valid ids for deprecated CourseLocator fields.
@@ -95,7 +96,7 @@ def deprecated_course_ids():
     )
 
 
-@_strategies.cacheable
+@cacheable
 def version_guids():
     """
     Strategy to generate valid ObjectIds.
@@ -122,7 +123,7 @@ def classdispatch(func):
 
 
 @classdispatch
-@_strategies.cacheable
+@cacheable
 def fields_for_key(cls, field):  # pylint: disable=unused-argument
     """
     A ``hypothesis`` strategy to generate data of the right type for the fields of this OpaqueKey.
@@ -150,7 +151,7 @@ def _aside_v1_exclusions(draw, strategy):
 
 
 @fields_for_key.register(AsideDefinitionKeyV1)
-@_strategies.cacheable
+@cacheable
 def _fields_for_aside_def_key_v1(cls, field):  # pylint: disable=missing-docstring
     if field == 'deprecated':
         return strategies.just(False)
@@ -162,7 +163,7 @@ def _fields_for_aside_def_key_v1(cls, field):  # pylint: disable=missing-docstri
 
 
 @fields_for_key.register(AsideUsageKeyV1)
-@_strategies.cacheable
+@cacheable
 def _fields_for_aside_usage_key_v1(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'deprecated':
         return strategies.just(False)
@@ -174,7 +175,7 @@ def _fields_for_aside_usage_key_v1(cls, field):  # pylint: disable=missing-docst
 
 
 @fields_for_key.register(AsideDefinitionKeyV2)
-@_strategies.cacheable
+@cacheable
 def _fields_for_aside_def_key_v2(cls, field):  # pylint: disable=missing-docstring
     if field == 'deprecated':
         return strategies.just(False)
@@ -184,7 +185,7 @@ def _fields_for_aside_def_key_v2(cls, field):  # pylint: disable=missing-docstri
 
 
 @fields_for_key.register(AsideUsageKeyV2)
-@_strategies.cacheable
+@cacheable
 def _fields_for_aside_usage_key_v2(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'deprecated':
         return strategies.just(False)
@@ -194,7 +195,7 @@ def _fields_for_aside_usage_key_v2(cls, field):  # pylint: disable=missing-docst
 
 
 @fields_for_key.register(LibraryLocator)
-@_strategies.cacheable
+@cacheable
 def _fields_for_library_locator(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'version_guid':
         return version_guids()
@@ -206,7 +207,7 @@ def _fields_for_library_locator(cls, field):  # pylint: disable=missing-docstrin
 
 
 @fields_for_key.register(LibraryLocatorV2)
-@_strategies.cacheable
+@cacheable
 def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'org':
         return ascii_identifier()
@@ -216,7 +217,7 @@ def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-docst
 
 
 @fields_for_key.register(DefinitionLocator)
-@_strategies.cacheable
+@cacheable
 def _fields_for_definition_locator(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'definition_id':
         return version_guids()
@@ -226,7 +227,7 @@ def _fields_for_definition_locator(cls, field):  # pylint: disable=missing-docst
 
 
 @fields_for_key.register(BundleDefinitionLocator)
-@_strategies.cacheable
+@cacheable
 def _fields_for_bundle_def_locator(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'bundle_uuid':
         return strategies.uuids()
@@ -240,7 +241,7 @@ def _fields_for_bundle_def_locator(cls, field):  # pylint: disable=missing-docst
 
 
 @fields_for_key.register(LibraryUsageLocatorV2)
-@_strategies.cacheable
+@cacheable
 def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-docstring, function-redefined
     if field == 'lib_key':
         return instances_of_key(LibraryLocatorV2)
@@ -252,7 +253,7 @@ def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-docst
 
 
 @classdispatch
-@_strategies.cacheable
+@cacheable
 def instances_of_key(cls, **kwargs):
     """
     A ``hypothesis`` strategy to generate instances of this OpaqueKey class.
@@ -277,7 +278,7 @@ def instances_of_key(cls, **kwargs):
 
 
 @instances_of_key.register(BlockTypeKeyV1)
-@_strategies.cacheable
+@cacheable
 def _instances_of_block_type_key(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
 
     return strategies.builds(
@@ -293,7 +294,7 @@ def _instances_of_block_type_key(cls, **kwargs):  # pylint: disable=missing-docs
 
 
 @instances_of_key.register(CourseLocator)
-@_strategies.cacheable
+@cacheable
 def _instances_of_course_locator(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
 
     return strategies.builds(
@@ -315,7 +316,7 @@ def _instances_of_course_locator(cls, **kwargs):  # pylint: disable=missing-docs
 
 
 @instances_of_key.register(BlockUsageLocator)
-@_strategies.cacheable
+@cacheable
 def _instances_of_block_usage(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
 
     def locator_for_course(course_key):
@@ -343,7 +344,7 @@ def _instances_of_block_usage(cls, **kwargs):  # pylint: disable=missing-docstri
 
 
 @instances_of_key.register(LibraryUsageLocator)
-@_strategies.cacheable
+@cacheable
 def _instances_of_library_usage(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
 
     return strategies.builds(
@@ -355,7 +356,7 @@ def _instances_of_library_usage(cls, **kwargs):  # pylint: disable=missing-docst
 
 
 @instances_of_key.register(DeprecatedLocation)
-@_strategies.cacheable
+@cacheable
 def _instances_of_deprecated_loc(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
 
     return strategies.builds(
@@ -371,7 +372,7 @@ def _instances_of_deprecated_loc(cls, **kwargs):  # pylint: disable=missing-docs
 
 
 @classdispatch
-@_strategies.cacheable
+@cacheable
 def keys_of_type(cls, blacklist=None):
     """
     A ``hypothesis`` strategy to generate instances of this OpaqueKey KeyType.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-pbr==5.4.3                # via stevedore
-pymongo==3.9.0
-six==1.13.0
-stevedore==1.31.0
+pbr==5.4.4                # via stevedore
+pymongo==3.10.1           # via -r requirements/base.in
+six==1.14.0               # via -r requirements/base.in, stevedore
+stevedore==1.32.0         # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,91 +4,95 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12
-apipkg==1.5
-astroid==1.6.6
-atomicwrites==1.3.0
-attrs==19.3.0
-babel==2.7.0
-backports.functools-lru-cache==1.6.1
-bleach==3.1.0
-certifi==2019.9.11
-cffi==1.13.2
-chardet==3.0.4
-click-log==0.3.2
-click==7.0
-configparser==4.0.2
-contextlib2==0.6.0.post1
-coverage==4.5.4
-coveralls==1.8.2
-cryptography==2.8
-ddt==1.2.1
-docopt==0.6.2
-docutils==0.15.2
-edx-lint==1.4.1
-edx-sphinx-theme==1.5.0
-enum34==1.1.6
-execnet==1.7.1
-filelock==3.0.12
-funcsigs==1.0.2
-futures==3.3.0 ; python_version == "2.7"
-hypothesis==4.44.1
-idna==2.8
-imagesize==1.1.0
-importlib-metadata==0.23
-ipaddress==1.0.23
-isort==4.3.21
-jinja2==2.10.3
-lazy-object-proxy==1.4.3
-markupsafe==1.1.1
-mccabe==0.6.1
-mock==3.0.5
-more-itertools==5.0.0
-packaging==19.2
-pathlib2==2.3.5
-pbr==5.4.3
-pep8==1.7.1
-pip-tools==4.2.0
-pluggy==0.13.0
-py==1.8.0
-pycodestyle==2.5.0
-pycparser==2.19
-pygments==2.4.2
-pylint-celery==0.3
-pylint-django==0.11.1
-pylint-plugin-utils==0.6
-pylint==1.9.5
-pymongo==3.9.0
-pyopenssl==19.0.0
-pyparsing==2.4.5
-pytest-cache==1.0
-pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest-forked==1.1.3
-pytest-pep8==1.0.6
-pytest-pylint==0.14.1
-pytest-xdist==1.30.0
-pytest==4.6.6
-pytz==2019.3
-readme-renderer==24.0
-requests==2.22.0
-scandir==1.10.0
-singledispatch==3.4.0.3
-six==1.13.0
-snowballstemmer==2.0.0
-sphinx==1.8.5
-sphinxcontrib-websupport==1.1.2
-stevedore==1.31.0
-toml==0.10.0
-tox-battery==0.5.1
-tox==3.14.0
-typing==3.7.4.1
-urllib3[secure]==1.25.7
-virtualenv==16.7.7
-wcwidth==0.1.7
-webencodings==0.5.1
-wrapt==1.11.2
-zipp==0.6.0
+alabaster==0.7.12         # via -r requirements/doc.txt, sphinx
+apipkg==1.5               # via -r requirements/doc.txt, execnet
+appdirs==1.4.3            # via -r requirements/travis.txt, virtualenv
+astroid==1.6.6            # via -r requirements/doc.txt, pylint, pylint-celery
+atomicwrites==1.3.0       # via -r requirements/doc.txt, pytest
+attrs==19.3.0             # via -r requirements/doc.txt, hypothesis, pytest
+babel==2.8.0              # via -r requirements/doc.txt, sphinx
+backports.functools-lru-cache==1.6.1  # via -r requirements/doc.txt, astroid, isort, pylint
+bleach==3.1.1             # via -r requirements/doc.txt, readme-renderer
+certifi==2019.11.28       # via -r requirements/doc.txt, -r requirements/travis.txt, requests, urllib3
+cffi==1.14.0              # via -r requirements/travis.txt, cryptography
+chardet==3.0.4            # via -r requirements/doc.txt, -r requirements/travis.txt, requests
+click-log==0.3.2          # via -r requirements/doc.txt, edx-lint
+click==7.1.1              # via -r requirements/doc.txt, -r requirements/pip-tools.txt, click-log, edx-lint, pip-tools
+configparser==4.0.2       # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, pylint
+contextlib2==0.6.0.post1  # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, virtualenv, zipp
+coverage==5.0.4           # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, pytest-cov
+coveralls==1.11.1         # via -r requirements/travis.txt
+cryptography==2.8         # via -r requirements/travis.txt, pyopenssl, urllib3
+ddt==1.3.0                # via -r requirements/doc.txt
+distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
+docopt==0.6.2             # via -r requirements/travis.txt, coveralls
+docutils==0.16            # via -r requirements/doc.txt, readme-renderer, sphinx
+edx-lint==1.4.1           # via -r requirements/doc.txt
+edx-sphinx-theme==1.5.0   # via -r requirements/doc.txt
+enum34==1.1.10            # via -r requirements/doc.txt, -r requirements/travis.txt, astroid, cryptography, hypothesis
+execnet==1.7.1            # via -r requirements/doc.txt, pytest-cache, pytest-xdist
+filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
+funcsigs==1.0.2           # via -r requirements/doc.txt, mock, pytest
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/doc.txt, isort
+hypothesis==4.57.1        # via -r requirements/doc.txt
+idna==2.9                 # via -r requirements/doc.txt, -r requirements/travis.txt, requests, urllib3
+imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
+importlib-metadata==1.5.0  # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-resources==1.3.1  # via -r requirements/travis.txt, virtualenv
+ipaddress==1.0.23         # via -r requirements/travis.txt, cryptography, urllib3
+isort==4.3.21             # via -r requirements/doc.txt, pylint
+jinja2==2.11.1            # via -r requirements/doc.txt, sphinx
+lazy-object-proxy==1.4.3  # via -r requirements/doc.txt, astroid
+markupsafe==1.1.1         # via -r requirements/doc.txt, jinja2
+mccabe==0.6.1             # via -r requirements/doc.txt, pylint
+mock==3.0.5               # via -r requirements/doc.txt
+more-itertools==5.0.0     # via -r requirements/doc.txt, pytest
+packaging==20.3           # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, sphinx, tox
+pathlib2==2.3.5           # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
+pbr==5.4.4                # via -r requirements/doc.txt, stevedore
+pep8==1.7.1               # via -r requirements/doc.txt, pytest-pep8
+pip-tools==4.5.1          # via -r requirements/pip-tools.txt
+pluggy==0.13.1            # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, tox
+py==1.8.1                 # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, tox
+pycodestyle==2.5.0        # via -r requirements/doc.txt
+pycparser==2.20           # via -r requirements/travis.txt, cffi
+pygments==2.5.2           # via -r requirements/doc.txt, readme-renderer, sphinx
+pylint-celery==0.3        # via -r requirements/doc.txt, edx-lint
+pylint-django==0.11.1     # via -r requirements/doc.txt, edx-lint
+pylint-plugin-utils==0.6  # via -r requirements/doc.txt, pylint-celery, pylint-django
+pylint==1.9.5             # via -r requirements/doc.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pymongo==3.10.1           # via -r requirements/doc.txt
+pyopenssl==19.1.0         # via -r requirements/travis.txt, urllib3
+pyparsing==2.4.6          # via -r requirements/doc.txt, -r requirements/travis.txt, packaging
+pytest-cache==1.0         # via -r requirements/doc.txt, pytest-pep8
+pytest-cov==2.8.1         # via -r requirements/doc.txt
+pytest-django==3.8.0      # via -r requirements/doc.txt
+pytest-forked==1.1.3      # via -r requirements/doc.txt, pytest-xdist
+pytest-pep8==1.0.6        # via -r requirements/doc.txt
+pytest-pylint==0.14.1     # via -r requirements/doc.txt
+pytest-xdist==1.31.0      # via -r requirements/doc.txt
+pytest==4.6.9             # via -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytz==2019.3              # via -r requirements/doc.txt, babel
+readme-renderer==25.0     # via -r requirements/doc.txt
+requests==2.23.0          # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, sphinx
+scandir==1.10.0           # via -r requirements/doc.txt, -r requirements/travis.txt, pathlib2
+singledispatch==3.4.0.3   # via -r requirements/doc.txt, -r requirements/travis.txt, astroid, importlib-resources, pylint
+six==1.14.0               # via -r requirements/doc.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, bleach, cryptography, edx-lint, edx-sphinx-theme, mock, more-itertools, packaging, pathlib2, pip-tools, pylint, pyopenssl, pytest, pytest-pylint, pytest-xdist, readme-renderer, singledispatch, sphinx, stevedore, tox, virtualenv
+snowballstemmer==2.0.0    # via -r requirements/doc.txt, sphinx
+sortedcontainers==2.1.0   # via -r requirements/doc.txt, hypothesis
+sphinx==1.8.5             # via -r requirements/doc.txt, edx-sphinx-theme
+sphinxcontrib-websupport==1.1.2  # via -r requirements/doc.txt, sphinx
+stevedore==1.32.0         # via -r requirements/doc.txt
+toml==0.10.0              # via -r requirements/travis.txt, tox
+tox-battery==0.5.2        # via -r requirements/travis.txt
+tox==3.14.5               # via -r requirements/travis.txt, tox-battery
+typing==3.7.4.1           # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-resources, sphinx
+urllib3[secure]==1.25.8   # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, requests
+virtualenv==20.0.10       # via -r requirements/travis.txt, tox
+wcwidth==0.1.8            # via -r requirements/doc.txt, pytest
+webencodings==0.5.1       # via -r requirements/doc.txt, bleach
+wrapt==1.12.1             # via -r requirements/doc.txt, astroid
+zipp==1.2.0               # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.6.0        # via sphinx
+# setuptools

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -4,54 +4,55 @@
 #
 #    make upgrade
 #
-apipkg==1.5
-astroid==1.6.6
-atomicwrites==1.3.0
-attrs==19.3.0
-backports.functools-lru-cache==1.6.1
-click-log==0.3.2
-click==7.0
-configparser==4.0.2
-contextlib2==0.6.0.post1
-coverage==4.5.4
-ddt==1.2.1
-edx-lint==1.4.1
-enum34==1.1.6
-execnet==1.7.1
-funcsigs==1.0.2
-futures==3.3.0 ; python_version == "2.7"
-hypothesis==4.44.1
-importlib-metadata==0.23
-isort==4.3.21
-lazy-object-proxy==1.4.3
-mccabe==0.6.1
-mock==3.0.5
-more-itertools==5.0.0
-packaging==19.2
-pathlib2==2.3.5
-pbr==5.4.3
-pep8==1.7.1
-pluggy==0.13.0
-py==1.8.0
-pycodestyle==2.5.0
-pylint-celery==0.3
-pylint-django==0.11.1
-pylint-plugin-utils==0.6
-pylint==1.9.5
-pymongo==3.9.0
-pyparsing==2.4.5
-pytest-cache==1.0
-pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest-forked==1.1.3
-pytest-pep8==1.0.6
-pytest-pylint==0.14.1
-pytest-xdist==1.30.0
-pytest==4.6.6
-scandir==1.10.0
-singledispatch==3.4.0.3
-six==1.13.0
-stevedore==1.31.0
-wcwidth==0.1.7
-wrapt==1.11.2
-zipp==0.6.0
+apipkg==1.5               # via -r requirements/test.txt, execnet
+astroid==1.6.6            # via -r requirements/test.txt, pylint, pylint-celery
+atomicwrites==1.3.0       # via -r requirements/test.txt, pytest
+attrs==19.3.0             # via -r requirements/test.txt, hypothesis, pytest
+backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, astroid, isort, pylint
+click-log==0.3.2          # via -r requirements/test.txt, edx-lint
+click==7.1.1              # via -r requirements/test.txt, click-log, edx-lint
+configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata, pylint
+contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
+coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
+ddt==1.3.0                # via -r requirements/test.txt
+edx-lint==1.4.1           # via -r requirements/test.txt
+enum34==1.1.10            # via -r requirements/test.txt, astroid, hypothesis
+execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-xdist
+funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, isort
+hypothesis==4.57.1        # via -r requirements/test.txt
+importlib-metadata==1.5.0  # via -r requirements/test.txt, pluggy, pytest
+isort==4.3.21             # via -r requirements/test.txt, pylint
+lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
+mccabe==0.6.1             # via -r requirements/test.txt, pylint
+mock==3.0.5               # via -r requirements/test.txt
+more-itertools==5.0.0     # via -r requirements/test.txt, pytest
+packaging==20.3           # via -r requirements/test.txt, pytest
+pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest, pytest-django
+pbr==5.4.4                # via -r requirements/test.txt, stevedore
+pep8==1.7.1               # via -r requirements/test.txt, pytest-pep8
+pluggy==0.13.1            # via -r requirements/test.txt, pytest
+py==1.8.1                 # via -r requirements/test.txt, pytest
+pycodestyle==2.5.0        # via -r requirements/test.txt
+pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
+pylint-django==0.11.1     # via -r requirements/test.txt, edx-lint
+pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
+pylint==1.9.5             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pymongo==3.10.1           # via -r requirements/test.txt
+pyparsing==2.4.6          # via -r requirements/test.txt, packaging
+pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
+pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-django==3.8.0      # via -r requirements/django.in
+pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
+pytest-pep8==1.0.6        # via -r requirements/test.txt
+pytest-pylint==0.14.1     # via -r requirements/test.txt
+pytest-xdist==1.31.0      # via -r requirements/test.txt
+pytest==4.6.9             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+scandir==1.10.0           # via -r requirements/test.txt, pathlib2
+singledispatch==3.4.0.3   # via -r requirements/test.txt, astroid, pylint
+six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, singledispatch, stevedore
+sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
+stevedore==1.32.0         # via -r requirements/test.txt
+wcwidth==0.1.8            # via -r requirements/test.txt, pytest
+wrapt==1.12.1             # via -r requirements/test.txt, astroid
+zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,77 +5,78 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-apipkg==1.5
-astroid==1.6.6
-atomicwrites==1.3.0
-attrs==19.3.0
-babel==2.7.0              # via sphinx
-backports.functools-lru-cache==1.6.1
-bleach==3.1.0             # via readme-renderer
-certifi==2019.9.11        # via requests
+apipkg==1.5               # via -r requirements/django.txt, execnet
+astroid==1.6.6            # via -r requirements/django.txt, pylint, pylint-celery
+atomicwrites==1.3.0       # via -r requirements/django.txt, pytest
+attrs==19.3.0             # via -r requirements/django.txt, hypothesis, pytest
+babel==2.8.0              # via sphinx
+backports.functools-lru-cache==1.6.1  # via -r requirements/django.txt, astroid, isort, pylint
+bleach==3.1.1             # via readme-renderer
+certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-click-log==0.3.2
-click==7.0
-configparser==4.0.2
-contextlib2==0.6.0.post1
-coverage==4.5.4
-ddt==1.2.1
-docutils==0.15.2          # via readme-renderer, sphinx
-edx-lint==1.4.1
-edx-sphinx-theme==1.5.0
-enum34==1.1.6
-execnet==1.7.1
-funcsigs==1.0.2
-futures==3.3.0 ; python_version == "2.7"
-hypothesis==4.44.1
-idna==2.8                 # via requests
-imagesize==1.1.0          # via sphinx
-importlib-metadata==0.23
-isort==4.3.21
-jinja2==2.10.3            # via sphinx
-lazy-object-proxy==1.4.3
+click-log==0.3.2          # via -r requirements/django.txt, edx-lint
+click==7.1.1              # via -r requirements/django.txt, click-log, edx-lint
+configparser==4.0.2       # via -r requirements/django.txt, importlib-metadata, pylint
+contextlib2==0.6.0.post1  # via -r requirements/django.txt, importlib-metadata, zipp
+coverage==5.0.4           # via -r requirements/django.txt, pytest-cov
+ddt==1.3.0                # via -r requirements/django.txt
+docutils==0.16            # via readme-renderer, sphinx
+edx-lint==1.4.1           # via -r requirements/django.txt
+edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
+enum34==1.1.10            # via -r requirements/django.txt, astroid, hypothesis
+execnet==1.7.1            # via -r requirements/django.txt, pytest-cache, pytest-xdist
+funcsigs==1.0.2           # via -r requirements/django.txt, mock, pytest
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/django.txt, isort
+hypothesis==4.57.1        # via -r requirements/django.txt
+idna==2.9                 # via requests
+imagesize==1.2.0          # via sphinx
+importlib-metadata==1.5.0  # via -r requirements/django.txt, pluggy, pytest
+isort==4.3.21             # via -r requirements/django.txt, pylint
+jinja2==2.11.1            # via sphinx
+lazy-object-proxy==1.4.3  # via -r requirements/django.txt, astroid
 markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1
-mock==3.0.5
-more-itertools==5.0.0
-packaging==19.2
-pathlib2==2.3.5
-pbr==5.4.3
-pep8==1.7.1
-pluggy==0.13.0
-py==1.8.0
-pycodestyle==2.5.0
-pygments==2.4.2           # via readme-renderer, sphinx
-pylint-celery==0.3
-pylint-django==0.11.1
-pylint-plugin-utils==0.6
-pylint==1.9.5
-pymongo==3.9.0
-pyparsing==2.4.5
-pytest-cache==1.0
-pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest-forked==1.1.3
-pytest-pep8==1.0.6
-pytest-pylint==0.14.1
-pytest-xdist==1.30.0
-pytest==4.6.6
+mccabe==0.6.1             # via -r requirements/django.txt, pylint
+mock==3.0.5               # via -r requirements/django.txt
+more-itertools==5.0.0     # via -r requirements/django.txt, pytest
+packaging==20.3           # via -r requirements/django.txt, pytest, sphinx
+pathlib2==2.3.5           # via -r requirements/django.txt, importlib-metadata, pytest, pytest-django
+pbr==5.4.4                # via -r requirements/django.txt, stevedore
+pep8==1.7.1               # via -r requirements/django.txt, pytest-pep8
+pluggy==0.13.1            # via -r requirements/django.txt, pytest
+py==1.8.1                 # via -r requirements/django.txt, pytest
+pycodestyle==2.5.0        # via -r requirements/django.txt
+pygments==2.5.2           # via readme-renderer, sphinx
+pylint-celery==0.3        # via -r requirements/django.txt, edx-lint
+pylint-django==0.11.1     # via -r requirements/django.txt, edx-lint
+pylint-plugin-utils==0.6  # via -r requirements/django.txt, pylint-celery, pylint-django
+pylint==1.9.5             # via -r requirements/django.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pymongo==3.10.1           # via -r requirements/django.txt
+pyparsing==2.4.6          # via -r requirements/django.txt, packaging
+pytest-cache==1.0         # via -r requirements/django.txt, pytest-pep8
+pytest-cov==2.8.1         # via -r requirements/django.txt
+pytest-django==3.8.0      # via -r requirements/django.txt
+pytest-forked==1.1.3      # via -r requirements/django.txt, pytest-xdist
+pytest-pep8==1.0.6        # via -r requirements/django.txt
+pytest-pylint==0.14.1     # via -r requirements/django.txt
+pytest-xdist==1.31.0      # via -r requirements/django.txt
+pytest==4.6.9             # via -r requirements/django.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2019.3              # via babel
-readme-renderer==24.0
-requests==2.22.0          # via sphinx
-scandir==1.10.0
-singledispatch==3.4.0.3
-six==1.13.0
+readme-renderer==25.0     # via -r requirements/doc.in
+requests==2.23.0          # via sphinx
+scandir==1.10.0           # via -r requirements/django.txt, pathlib2
+singledispatch==3.4.0.3   # via -r requirements/django.txt, astroid, pylint
+six==1.14.0               # via -r requirements/django.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, readme-renderer, singledispatch, sphinx, stevedore
 snowballstemmer==2.0.0    # via sphinx
-sphinx==1.8.5
+sortedcontainers==2.1.0   # via -r requirements/django.txt, hypothesis
+sphinx==1.8.5             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-websupport==1.1.2  # via sphinx
-stevedore==1.31.0
+stevedore==1.32.0         # via -r requirements/django.txt
 typing==3.7.4.1           # via sphinx
-urllib3==1.25.7           # via requests
-wcwidth==0.1.7
+urllib3==1.25.8           # via requests
+wcwidth==0.1.8            # via -r requirements/django.txt, pytest
 webencodings==0.5.1       # via bleach
-wrapt==1.11.2
-zipp==0.6.0
+wrapt==1.12.1             # via -r requirements/django.txt, astroid
+zipp==1.2.0               # via -r requirements/django.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.6.0        # via sphinx
+# setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,6 @@
 #
 #    make upgrade
 #
-click==7.0                # via pip-tools
-pip-tools==4.2.0
-six==1.13.0               # via pip-tools
+click==7.1.1              # via pip-tools
+pip-tools==4.5.1          # via -r requirements/pip-tools.in
+six==1.14.0               # via pip-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,47 +10,48 @@ atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via hypothesis, pytest
 backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
 click-log==0.3.2          # via edx-lint
-click==7.0                # via click-log, edx-lint
+click==7.1.1              # via click-log, edx-lint
 configparser==4.0.2       # via importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via importlib-metadata
-coverage==4.5.4
-ddt==1.2.1
-edx-lint==1.4.1
-enum34==1.1.6             # via astroid, hypothesis
+contextlib2==0.6.0.post1  # via importlib-metadata, zipp
+coverage==5.0.4           # via -r requirements/test.in, pytest-cov
+ddt==1.3.0                # via -r requirements/test.in
+edx-lint==1.4.1           # via -r requirements/test.in
+enum34==1.1.10            # via astroid, hypothesis
 execnet==1.7.1            # via pytest-cache, pytest-xdist
 funcsigs==1.0.2           # via mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via isort
-hypothesis==4.44.1
-importlib-metadata==0.23  # via pluggy, pytest
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, isort
+hypothesis==4.57.1        # via -r requirements/test.in
+importlib-metadata==1.5.0  # via pluggy, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
-mock==3.0.5
-more-itertools==5.0.0     # via pytest, zipp
-packaging==19.2           # via pytest
+mock==3.0.5               # via -r requirements/test.in
+more-itertools==5.0.0     # via pytest
+packaging==20.3           # via pytest
 pathlib2==2.3.5           # via importlib-metadata, pytest
-pbr==5.4.3
+pbr==5.4.4                # via -r requirements/base.txt, stevedore
 pep8==1.7.1               # via pytest-pep8
-pluggy==0.13.0            # via pytest
-py==1.8.0                 # via pytest
-pycodestyle==2.5.0
+pluggy==0.13.1            # via pytest
+py==1.8.1                 # via pytest
+pycodestyle==2.5.0        # via -r requirements/test.in
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.11.1     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
-pymongo==3.9.0
-pyparsing==2.4.5          # via packaging
+pymongo==3.10.1           # via -r requirements/base.txt
+pyparsing==2.4.6          # via packaging
 pytest-cache==1.0         # via pytest-pep8
-pytest-cov==2.8.1
+pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-forked==1.1.3      # via pytest-xdist
-pytest-pep8==1.0.6
-pytest-pylint==0.14.1
-pytest-xdist==1.30.0
-pytest==4.6.6
+pytest-pep8==1.0.6        # via -r requirements/test.in
+pytest-pylint==0.14.1     # via -r requirements/test.in
+pytest-xdist==1.31.0      # via -r requirements/test.in
+pytest==4.6.9             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 scandir==1.10.0           # via pathlib2
-singledispatch==3.4.0.3
-six==1.13.0
-stevedore==1.31.0
-wcwidth==0.1.7            # via pytest
-wrapt==1.11.2             # via astroid
-zipp==0.6.0               # via importlib-metadata
+singledispatch==3.4.0.3   # via -r requirements/test.in, astroid, pylint
+six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, singledispatch, stevedore
+sortedcontainers==2.1.0   # via hypothesis
+stevedore==1.32.0         # via -r requirements/base.txt
+wcwidth==0.1.8            # via pytest
+wrapt==1.12.1             # via astroid
+zipp==1.2.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,34 +4,38 @@
 #
 #    make upgrade
 #
-certifi==2019.9.11        # via requests, urllib3
-cffi==1.13.2              # via cryptography
+appdirs==1.4.3            # via virtualenv
+certifi==2019.11.28       # via requests, urllib3
+cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
-coverage==4.5.4           # via coveralls
-coveralls==1.8.2
+contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
+coverage==5.0.4           # via coveralls
+coveralls==1.11.1         # via -r requirements/travis.in
 cryptography==2.8         # via pyopenssl, urllib3
+distlib==0.3.0            # via virtualenv
 docopt==0.6.2             # via coveralls
-enum34==1.1.6             # via cryptography
-filelock==3.0.12          # via tox
-idna==2.8                 # via requests, urllib3
-importlib-metadata==0.23  # via pluggy, tox
+enum34==1.1.10            # via cryptography
+filelock==3.0.12          # via tox, virtualenv
+idna==2.9                 # via requests, urllib3
+importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.3.1  # via virtualenv
 ipaddress==1.0.23         # via cryptography, urllib3
-more-itertools==5.0.0     # via zipp
-packaging==19.2           # via tox
-pathlib2==2.3.5           # via importlib-metadata
-pluggy==0.13.0            # via tox
-py==1.8.0                 # via tox
-pycparser==2.19           # via cffi
-pyopenssl==19.0.0         # via urllib3
-pyparsing==2.4.5          # via packaging
-requests==2.22.0          # via coveralls
+packaging==20.3           # via tox
+pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
+pluggy==0.13.1            # via tox
+py==1.8.1                 # via tox
+pycparser==2.20           # via cffi
+pyopenssl==19.1.0         # via urllib3
+pyparsing==2.4.6          # via packaging
+requests==2.23.0          # via coveralls
 scandir==1.10.0           # via pathlib2
-six==1.13.0               # via cryptography, more-itertools, packaging, pathlib2, pyopenssl, tox
+singledispatch==3.4.0.3   # via importlib-resources
+six==1.14.0               # via cryptography, packaging, pathlib2, pyopenssl, singledispatch, tox, virtualenv
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.0
-urllib3[secure]==1.25.7   # via coveralls, requests
-virtualenv==16.7.7        # via tox
-zipp==0.6.0               # via importlib-metadata
+tox-battery==0.5.2        # via -r requirements/travis.in
+tox==3.14.5               # via -r requirements/travis.in, tox-battery
+typing==3.7.4.1           # via importlib-resources
+urllib3[secure]==1.25.8   # via coveralls, requests
+virtualenv==20.0.10       # via tox
+zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,4 @@ commands = pytest --disable-pytest-warnings --ignore=opaque_keys/edx/django {pos
 [testenv:quality]
 commands=
     pycodestyle --config=.pep8 opaque_keys
-	pylint --rcfile=pylintrc opaque_keys
+    pylint --rcfile=pylintrc opaque_keys


### PR DESCRIPTION
- Change Hypothesis import due to internal API change in 4.53.2
- Reduce Hypothesis [`max_examples`](https://hypothesis.readthedocs.io/en/latest/settings.html#hypothesis.settings.max_examples) for the CI profile to keep test times roughly as they were with older version. This drops average test run time from approximately 15 to 10 minutes, but it would have increased to 30 minutes without this change, with timeouts due to >10 minute pauses for some tests.
- Fix indentation