### PR TITLE
Drop Python 2.7; fix use of requirements files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
 
 env:
@@ -10,18 +9,9 @@ env:
   - TOXENV=django22
 
 matrix:
-  exclude:
-    - python: "2.7"
-      env: TOXENV=django20
-    - python: "2.7"
-      env: TOXENV=django21
-    - python: "2.7"
-      env: TOXENV=django22
   include:
     - python: "3.5"
       env: TOXENV=quality
-    - python: "2.7"
-      env: TOXENV=pytest-py27
     - python: "3.5"
       env: TOXENV=pytest-py35
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,14 @@
 # Unreleased
 
+# 3.0
+
+* Drop support for Python 2.7
+* Change `DefinitionLocator.version` from method to property
+* Bugix: setup.py now properly uses requirements files
+
+# 2.1
+
+* Declare support for Python 3.5 and Django 2.2
 
 # 2.0
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,15 @@
 
 # 3.0
 
+Breaking changes:
+
 * Drop support for Python 2.7
-* Change `DefinitionLocator.version` from method to property
-* Bugix: setup.py now properly uses requirements files
+* Change ``DefinitionLocator.version`` from method to property to match
+  parent class
+
+Bugfixes:
+
+* setup.py now properly uses requirements files
 
 # 2.1
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include CHANGELOG.rst
+include LICENSE
+include README.rst
+include requirements/base.in
+recursive-include opaque_keys *.html *.png *.gif *js *.css *jpg *jpeg *svg *py

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -23,7 +23,7 @@ from opaque_keys.edx.keys import BlockTypeKey, CourseKey, LearningContextKey, Us
 log = logging.getLogger(__name__)
 
 
-class _Creator(object):
+class _Creator:
     """
     DO NOT REUSE THIS CLASS. Provided for backwards compatibility only!
 
@@ -42,7 +42,7 @@ class _Creator(object):
 
 
 # pylint: disable=missing-docstring,unused-argument
-class CreatorMixin(object):
+class CreatorMixin:
     """
     Mixin class to provide SubfieldBase functionality to django fields.
     See: https://docs.djangoproject.com/en/1.11/releases/1.8/#subfieldbase

--- a/opaque_keys/edx/django/tests/models.py
+++ b/opaque_keys/edx/django/tests/models.py
@@ -16,7 +16,7 @@ from opaque_keys.edx.django.models import (
 )
 
 
-class Container(object):
+class Container:
     """A simple wrapper class for string-like objects."""
 
     def __init__(self, text):

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -107,7 +107,7 @@ class DefinitionKey(OpaqueKey):
         raise NotImplementedError()
 
 
-class CourseObjectMixin(object):
+class CourseObjectMixin:
     """
     An abstract :class:`opaque_keys.OpaqueKey` mixin
     for keys that belong to courses.

--- a/opaque_keys/edx/locations.py
+++ b/opaque_keys/edx/locations.py
@@ -65,7 +65,7 @@ class SlashSeparatedCourseKey(CourseLocator):
         )
 
 
-class LocationBase(object):
+class LocationBase:
     """Deprecated. Base class for :class:`Location` and :class:`AssetLocation`"""
 
     DEPRECATED_TAG = None  # Subclasses should define what DEPRECATED_TAG is

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -23,7 +23,7 @@ from opaque_keys.edx.keys import AssetKey, CourseKey, DefinitionKey, LearningCon
 log = logging.getLogger(__name__)
 
 
-class LocalId(object):
+class LocalId:
     """
     Class for local ids for non-persisted xblocks (which can have hardcoded block_ids if necessary)
     """
@@ -72,7 +72,7 @@ class Locator(OpaqueKey):
             raise InvalidKeyError(cls, u'"%s" is not a valid version_guid' % value)
 
 
-class CheckFieldMixin(object):
+class CheckFieldMixin:
     """
     Mixin that provides handy methods for checking field types/values.
     """
@@ -1220,6 +1220,7 @@ class DefinitionLocator(Locator, DefinitionKey):
 
         return cls(**{key: parse.get(key) for key in cls.KEY_FIELDS})
 
+    @property
     def version(self):
         """
         Returns the ObjectId referencing this specific location.
@@ -1227,7 +1228,7 @@ class DefinitionLocator(Locator, DefinitionKey):
         return self.definition_id
 
 
-class VersionTree(object):
+class VersionTree:
     """
     Holds trees of Locators to represent version histories.
     """

--- a/opaque_keys/edx/tests/__init__.py
+++ b/opaque_keys/edx/tests/__init__.py
@@ -15,7 +15,8 @@ class TestDeprecated(TestCase):
         # during this test run
         self.cws = warnings.catch_warnings()
         self.cws.__enter__()
-        # Python 2.7 by default suppresses DeprecationWarnings. Make sure we show these, always, during tests.
+        # Python from 3.2 until 3.7 by default suppresses DeprecationWarnings.
+        # Make sure we show these, always, during tests.
         warnings.simplefilter('always', DeprecationWarning)
 
         # Manually exit the catch_warnings context manager when the test is done

--- a/opaque_keys/edx/tests/test_locators.py
+++ b/opaque_keys/edx/tests/test_locators.py
@@ -40,7 +40,7 @@ class DefinitionLocatorTests(TestCase):
     def test_description_locator_version(self):
         object_id = '{:024x}'.format(random.randrange(16 ** 24))
         definition_locator = DefinitionLocator('html', object_id)
-        self.assertEqual(object_id, str(definition_locator.version()))
+        self.assertEqual(object_id, str(definition_locator.version))
 
 
 @ddt.ddt

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Core requirements for using this application
 -c constraints.txt
 
-pymongo>=2.7.2,<4.0.0
-six>=1.10.0,<2.0.0'
-stevedore>=0.14.1,<2.0.0'
+pymongo
+six
+stevedore

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Core requirements for using this application
 -c constraints.txt
 
-pymongo
-six
-stevedore
+pymongo>=2.7.2
+six>=1.10.0
+stevedore>=0.14.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,7 +7,3 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
-
-# These packages are backports which can only be installed on Python 2.7
-functools32 ; python_version == "2.7"
-futures ; python_version == "2.7"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,91 +7,83 @@
 alabaster==0.7.12         # via -r requirements/doc.txt, sphinx
 apipkg==1.5               # via -r requirements/doc.txt, execnet
 appdirs==1.4.3            # via -r requirements/travis.txt, virtualenv
-astroid==1.6.6            # via -r requirements/doc.txt, pylint, pylint-celery
-atomicwrites==1.3.0       # via -r requirements/doc.txt, pytest
+astroid==2.3.3            # via -r requirements/doc.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/doc.txt, hypothesis, pytest
 babel==2.8.0              # via -r requirements/doc.txt, sphinx
-backports.functools-lru-cache==1.6.1  # via -r requirements/doc.txt, astroid, isort, pylint
-bleach==3.1.1             # via -r requirements/doc.txt, readme-renderer
-certifi==2019.11.28       # via -r requirements/doc.txt, -r requirements/travis.txt, requests, urllib3
-cffi==1.14.0              # via -r requirements/travis.txt, cryptography
+bleach==3.1.3             # via -r requirements/doc.txt, readme-renderer
+certifi==2019.11.28       # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/doc.txt, edx-lint
 click==7.1.1              # via -r requirements/doc.txt, -r requirements/pip-tools.txt, click-log, edx-lint, pip-tools
-configparser==4.0.2       # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, virtualenv, zipp
 coverage==5.0.4           # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, pytest-cov
 coveralls==1.11.1         # via -r requirements/travis.txt
-cryptography==2.8         # via -r requirements/travis.txt, pyopenssl, urllib3
 ddt==1.3.0                # via -r requirements/doc.txt
 distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
 docopt==0.6.2             # via -r requirements/travis.txt, coveralls
 docutils==0.16            # via -r requirements/doc.txt, readme-renderer, sphinx
 edx-lint==1.4.1           # via -r requirements/doc.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.txt
-enum34==1.1.10            # via -r requirements/doc.txt, -r requirements/travis.txt, astroid, cryptography, hypothesis
 execnet==1.7.1            # via -r requirements/doc.txt, pytest-cache, pytest-xdist
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
-funcsigs==1.0.2           # via -r requirements/doc.txt, mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/doc.txt, isort
-hypothesis==4.57.1        # via -r requirements/doc.txt
-idna==2.9                 # via -r requirements/doc.txt, -r requirements/travis.txt, requests, urllib3
+hypothesis==5.6.0         # via -r requirements/doc.txt
+idna==2.9                 # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
 importlib-metadata==1.5.0  # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-resources, pluggy, pytest, tox, virtualenv
 importlib-resources==1.3.1  # via -r requirements/travis.txt, virtualenv
-ipaddress==1.0.23         # via -r requirements/travis.txt, cryptography, urllib3
 isort==4.3.21             # via -r requirements/doc.txt, pylint
 jinja2==2.11.1            # via -r requirements/doc.txt, sphinx
 lazy-object-proxy==1.4.3  # via -r requirements/doc.txt, astroid
 markupsafe==1.1.1         # via -r requirements/doc.txt, jinja2
 mccabe==0.6.1             # via -r requirements/doc.txt, pylint
 mock==3.0.5               # via -r requirements/doc.txt
-more-itertools==5.0.0     # via -r requirements/doc.txt, pytest
+more-itertools==8.2.0     # via -r requirements/doc.txt, pytest
 packaging==20.3           # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, sphinx, tox
-pathlib2==2.3.5           # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
+pathlib2==2.3.5           # via -r requirements/doc.txt, pytest
 pbr==5.4.4                # via -r requirements/doc.txt, stevedore
 pep8==1.7.1               # via -r requirements/doc.txt, pytest-pep8
 pip-tools==4.5.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, tox
 py==1.8.1                 # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.5.0        # via -r requirements/doc.txt
-pycparser==2.20           # via -r requirements/travis.txt, cffi
-pygments==2.5.2           # via -r requirements/doc.txt, readme-renderer, sphinx
+pygments==2.6.1           # via -r requirements/doc.txt, readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/doc.txt, edx-lint
-pylint-django==0.11.1     # via -r requirements/doc.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/doc.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/doc.txt, pylint-celery, pylint-django
-pylint==1.9.5             # via -r requirements/doc.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pylint==2.4.2             # via -r requirements/doc.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
 pymongo==3.10.1           # via -r requirements/doc.txt
-pyopenssl==19.1.0         # via -r requirements/travis.txt, urllib3
 pyparsing==2.4.6          # via -r requirements/doc.txt, -r requirements/travis.txt, packaging
 pytest-cache==1.0         # via -r requirements/doc.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/doc.txt
 pytest-django==3.8.0      # via -r requirements/doc.txt
 pytest-forked==1.1.3      # via -r requirements/doc.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/doc.txt
-pytest-pylint==0.14.1     # via -r requirements/doc.txt
+pytest-pylint==0.15.1     # via -r requirements/doc.txt
 pytest-xdist==1.31.0      # via -r requirements/doc.txt
-pytest==4.6.9             # via -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==5.4.1             # via -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2019.3              # via -r requirements/doc.txt, babel
 readme-renderer==25.0     # via -r requirements/doc.txt
 requests==2.23.0          # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, sphinx
-scandir==1.10.0           # via -r requirements/doc.txt, -r requirements/travis.txt, pathlib2
-singledispatch==3.4.0.3   # via -r requirements/doc.txt, -r requirements/travis.txt, astroid, importlib-resources, pylint
-six==1.14.0               # via -r requirements/doc.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, bleach, cryptography, edx-lint, edx-sphinx-theme, mock, more-itertools, packaging, pathlib2, pip-tools, pylint, pyopenssl, pytest, pytest-pylint, pytest-xdist, readme-renderer, singledispatch, sphinx, stevedore, tox, virtualenv
+singledispatch==3.4.0.3   # via -r requirements/doc.txt
+six==1.14.0               # via -r requirements/doc.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pip-tools, pytest-xdist, readme-renderer, singledispatch, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/doc.txt, sphinx
 sortedcontainers==2.1.0   # via -r requirements/doc.txt, hypothesis
-sphinx==1.8.5             # via -r requirements/doc.txt, edx-sphinx-theme
-sphinxcontrib-websupport==1.1.2  # via -r requirements/doc.txt, sphinx
+sphinx==2.4.4             # via -r requirements/doc.txt, edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-devhelp==1.0.2  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-jsmath==1.0.1  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-qthelp==1.0.3  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/doc.txt, sphinx
 stevedore==1.32.0         # via -r requirements/doc.txt
 toml==0.10.0              # via -r requirements/travis.txt, tox
 tox-battery==0.5.2        # via -r requirements/travis.txt
 tox==3.14.5               # via -r requirements/travis.txt, tox-battery
-typing==3.7.4.1           # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-resources, sphinx
-urllib3[secure]==1.25.8   # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, requests
+typed-ast==1.4.1          # via -r requirements/doc.txt, astroid
+urllib3==1.25.8           # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 virtualenv==20.0.10       # via -r requirements/travis.txt, tox
 wcwidth==0.1.8            # via -r requirements/doc.txt, pytest
 webencodings==0.5.1       # via -r requirements/doc.txt, bleach
-wrapt==1.12.1             # via -r requirements/doc.txt, astroid
+wrapt==1.11.2             # via -r requirements/doc.txt, astroid
 zipp==1.2.0               # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -5,39 +5,32 @@
 #    make upgrade
 #
 apipkg==1.5               # via -r requirements/test.txt, execnet
-astroid==1.6.6            # via -r requirements/test.txt, pylint, pylint-celery
-atomicwrites==1.3.0       # via -r requirements/test.txt, pytest
+astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, hypothesis, pytest
-backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, astroid, isort, pylint
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.1              # via -r requirements/test.txt, click-log, edx-lint
-configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
 coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
 ddt==1.3.0                # via -r requirements/test.txt
 edx-lint==1.4.1           # via -r requirements/test.txt
-enum34==1.1.10            # via -r requirements/test.txt, astroid, hypothesis
 execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-xdist
-funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, isort
-hypothesis==4.57.1        # via -r requirements/test.txt
+hypothesis==5.6.0         # via -r requirements/test.txt
 importlib-metadata==1.5.0  # via -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
-more-itertools==5.0.0     # via -r requirements/test.txt, pytest
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 packaging==20.3           # via -r requirements/test.txt, pytest
-pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest, pytest-django
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.4                # via -r requirements/test.txt, stevedore
 pep8==1.7.1               # via -r requirements/test.txt, pytest-pep8
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.8.1                 # via -r requirements/test.txt, pytest
 pycodestyle==2.5.0        # via -r requirements/test.txt
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==0.11.1     # via -r requirements/test.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==1.9.5             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
 pymongo==3.10.1           # via -r requirements/test.txt
 pyparsing==2.4.6          # via -r requirements/test.txt, packaging
 pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
@@ -45,14 +38,14 @@ pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.8.0      # via -r requirements/django.in
 pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
-pytest-pylint==0.14.1     # via -r requirements/test.txt
+pytest-pylint==0.15.1     # via -r requirements/test.txt
 pytest-xdist==1.31.0      # via -r requirements/test.txt
-pytest==4.6.9             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-scandir==1.10.0           # via -r requirements/test.txt, pathlib2
-singledispatch==3.4.0.3   # via -r requirements/test.txt, astroid, pylint
-six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, singledispatch, stevedore
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+singledispatch==3.4.0.3   # via -r requirements/test.txt
+six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore
 sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
 stevedore==1.32.0         # via -r requirements/test.txt
+typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 wcwidth==0.1.8            # via -r requirements/test.txt, pytest
-wrapt==1.12.1             # via -r requirements/test.txt, astroid
+wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,28 +6,21 @@
 #
 alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via -r requirements/django.txt, execnet
-astroid==1.6.6            # via -r requirements/django.txt, pylint, pylint-celery
-atomicwrites==1.3.0       # via -r requirements/django.txt, pytest
+astroid==2.3.3            # via -r requirements/django.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/django.txt, hypothesis, pytest
 babel==2.8.0              # via sphinx
-backports.functools-lru-cache==1.6.1  # via -r requirements/django.txt, astroid, isort, pylint
-bleach==3.1.1             # via readme-renderer
+bleach==3.1.3             # via readme-renderer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via -r requirements/django.txt, edx-lint
 click==7.1.1              # via -r requirements/django.txt, click-log, edx-lint
-configparser==4.0.2       # via -r requirements/django.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/django.txt, importlib-metadata, zipp
 coverage==5.0.4           # via -r requirements/django.txt, pytest-cov
 ddt==1.3.0                # via -r requirements/django.txt
 docutils==0.16            # via readme-renderer, sphinx
 edx-lint==1.4.1           # via -r requirements/django.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-enum34==1.1.10            # via -r requirements/django.txt, astroid, hypothesis
 execnet==1.7.1            # via -r requirements/django.txt, pytest-cache, pytest-xdist
-funcsigs==1.0.2           # via -r requirements/django.txt, mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/django.txt, isort
-hypothesis==4.57.1        # via -r requirements/django.txt
+hypothesis==5.6.0         # via -r requirements/django.txt
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.5.0  # via -r requirements/django.txt, pluggy, pytest
@@ -37,19 +30,19 @@ lazy-object-proxy==1.4.3  # via -r requirements/django.txt, astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/django.txt, pylint
 mock==3.0.5               # via -r requirements/django.txt
-more-itertools==5.0.0     # via -r requirements/django.txt, pytest
+more-itertools==8.2.0     # via -r requirements/django.txt, pytest
 packaging==20.3           # via -r requirements/django.txt, pytest, sphinx
-pathlib2==2.3.5           # via -r requirements/django.txt, importlib-metadata, pytest, pytest-django
+pathlib2==2.3.5           # via -r requirements/django.txt, pytest
 pbr==5.4.4                # via -r requirements/django.txt, stevedore
 pep8==1.7.1               # via -r requirements/django.txt, pytest-pep8
 pluggy==0.13.1            # via -r requirements/django.txt, pytest
 py==1.8.1                 # via -r requirements/django.txt, pytest
 pycodestyle==2.5.0        # via -r requirements/django.txt
-pygments==2.5.2           # via readme-renderer, sphinx
+pygments==2.6.1           # via readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/django.txt, edx-lint
-pylint-django==0.11.1     # via -r requirements/django.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/django.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/django.txt, pylint-celery, pylint-django
-pylint==1.9.5             # via -r requirements/django.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pylint==2.4.2             # via -r requirements/django.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
 pymongo==3.10.1           # via -r requirements/django.txt
 pyparsing==2.4.6          # via -r requirements/django.txt, packaging
 pytest-cache==1.0         # via -r requirements/django.txt, pytest-pep8
@@ -57,25 +50,29 @@ pytest-cov==2.8.1         # via -r requirements/django.txt
 pytest-django==3.8.0      # via -r requirements/django.txt
 pytest-forked==1.1.3      # via -r requirements/django.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/django.txt
-pytest-pylint==0.14.1     # via -r requirements/django.txt
+pytest-pylint==0.15.1     # via -r requirements/django.txt
 pytest-xdist==1.31.0      # via -r requirements/django.txt
-pytest==4.6.9             # via -r requirements/django.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==5.4.1             # via -r requirements/django.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2019.3              # via babel
 readme-renderer==25.0     # via -r requirements/doc.in
 requests==2.23.0          # via sphinx
-scandir==1.10.0           # via -r requirements/django.txt, pathlib2
-singledispatch==3.4.0.3   # via -r requirements/django.txt, astroid, pylint
-six==1.14.0               # via -r requirements/django.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, readme-renderer, singledispatch, sphinx, stevedore
+singledispatch==3.4.0.3   # via -r requirements/django.txt
+six==1.14.0               # via -r requirements/django.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pytest-xdist, readme-renderer, singledispatch, stevedore
 snowballstemmer==2.0.0    # via sphinx
 sortedcontainers==2.1.0   # via -r requirements/django.txt, hypothesis
-sphinx==1.8.5             # via -r requirements/doc.in, edx-sphinx-theme
-sphinxcontrib-websupport==1.1.2  # via sphinx
+sphinx==2.4.4             # via -r requirements/doc.in, edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
+sphinxcontrib-jsmath==1.0.1  # via sphinx
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 stevedore==1.32.0         # via -r requirements/django.txt
-typing==3.7.4.1           # via sphinx
+typed-ast==1.4.1          # via -r requirements/django.txt, astroid
 urllib3==1.25.8           # via requests
 wcwidth==0.1.8            # via -r requirements/django.txt, pytest
 webencodings==0.5.1       # via bleach
-wrapt==1.12.1             # via -r requirements/django.txt, astroid
+wrapt==1.11.2             # via -r requirements/django.txt, astroid
 zipp==1.2.0               # via -r requirements/django.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,7 +6,7 @@
 coverage
 ddt
 edx-lint
-hypothesis>=3.84.5
+hypothesis
 mock
 pycodestyle
 pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,53 +5,46 @@
 #    make upgrade
 #
 apipkg==1.5               # via execnet
-astroid==1.6.6            # via pylint, pylint-celery
-atomicwrites==1.3.0       # via pytest
+astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via hypothesis, pytest
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
 click-log==0.3.2          # via edx-lint
 click==7.1.1              # via click-log, edx-lint
-configparser==4.0.2       # via importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via importlib-metadata, zipp
 coverage==5.0.4           # via -r requirements/test.in, pytest-cov
 ddt==1.3.0                # via -r requirements/test.in
 edx-lint==1.4.1           # via -r requirements/test.in
-enum34==1.1.10            # via astroid, hypothesis
 execnet==1.7.1            # via pytest-cache, pytest-xdist
-funcsigs==1.0.2           # via mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, isort
-hypothesis==4.57.1        # via -r requirements/test.in
+hypothesis==5.6.0         # via -r requirements/test.in
 importlib-metadata==1.5.0  # via pluggy, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==5.0.0     # via pytest
+more-itertools==8.2.0     # via pytest
 packaging==20.3           # via pytest
-pathlib2==2.3.5           # via importlib-metadata, pytest
+pathlib2==2.3.5           # via pytest
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via -r requirements/test.in
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.11.1     # via edx-lint
+pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
 pymongo==3.10.1           # via -r requirements/base.txt
 pyparsing==2.4.6          # via packaging
 pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.in
-pytest-pylint==0.14.1     # via -r requirements/test.in
+pytest-pylint==0.15.1     # via -r requirements/test.in
 pytest-xdist==1.31.0      # via -r requirements/test.in
-pytest==4.6.9             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-scandir==1.10.0           # via pathlib2
-singledispatch==3.4.0.3   # via -r requirements/test.in, astroid, pylint
-six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, singledispatch, stevedore
+pytest==5.4.1             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+singledispatch==3.4.0.3   # via -r requirements/test.in
+six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore
 sortedcontainers==2.1.0   # via hypothesis
 stevedore==1.32.0         # via -r requirements/base.txt
+typed-ast==1.4.1          # via astroid
 wcwidth==0.1.8            # via pytest
-wrapt==1.12.1             # via astroid
+wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,37 +5,25 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-certifi==2019.11.28       # via requests, urllib3
-cffi==1.14.0              # via cryptography
+certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
 coverage==5.0.4           # via coveralls
 coveralls==1.11.1         # via -r requirements/travis.in
-cryptography==2.8         # via pyopenssl, urllib3
 distlib==0.3.0            # via virtualenv
 docopt==0.6.2             # via coveralls
-enum34==1.1.10            # via cryptography
 filelock==3.0.12          # via tox, virtualenv
-idna==2.9                 # via requests, urllib3
+idna==2.9                 # via requests
 importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
 importlib-resources==1.3.1  # via virtualenv
-ipaddress==1.0.23         # via cryptography, urllib3
 packaging==20.3           # via tox
-pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pycparser==2.20           # via cffi
-pyopenssl==19.1.0         # via urllib3
 pyparsing==2.4.6          # via packaging
 requests==2.23.0          # via coveralls
-scandir==1.10.0           # via pathlib2
-singledispatch==3.4.0.3   # via importlib-resources
-six==1.14.0               # via cryptography, packaging, pathlib2, pyopenssl, singledispatch, tox, virtualenv
+six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/travis.in
 tox==3.14.5               # via -r requirements/travis.in, tox-battery
-typing==3.7.4.1           # via importlib-resources
-urllib3[secure]==1.25.8   # via coveralls, requests
+urllib3==1.25.8           # via requests
 virtualenv==20.0.10       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Package metadata for edx-opaque-keys.
+"""
+from io import open
+
 from setuptools import setup, find_packages
+
+def load_requirements(*requirements_paths):
+    """
+    Load all requirements from the specified requirements files.
+
+    Returns:
+        list: Requirements file relative path strings
+    """
+    requirements = set()
+    for path in requirements_paths:
+        with open(path) as reqs:
+            requirements.update(
+                line.split('#')[0].strip() for line in reqs
+                if is_requirement(line.strip())
+            )
+    return list(requirements)
+
+
+def is_requirement(line):
+    """
+    Return True if the requirement line is a package requirement.
+
+    Returns:
+        bool: True if the line is not blank, a comment, a URL, or an included file
+    """
+    return line and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
 
 setup(
     name='edx-opaque-keys',
@@ -18,14 +51,7 @@ setup(
     # We are including the tests because other libraries do use mixins from them.
     packages=find_packages(),
     license='AGPL-3.0',
-    install_requires=[
-        'six>=1.10.0,<2.0.0',
-        'stevedore>=0.14.1,<2.0.0',
-        'pymongo>=2.7.2,<4.0.0'
-    ],
-    extras_require={
-        'django': ['Django>=1.11,<2.0;python_version<"3"', 'Django>=1.11;python_version>"3"']
-    },
+    install_requires=load_requirements('requirements/base.in'),
     entry_points={
         'opaque_keys.testing': [
             'base10 = opaque_keys.tests.test_opaque_keys:Base10Key',

--- a/setup.py
+++ b/setup.py
@@ -35,15 +35,13 @@ def is_requirement(line):
 
 setup(
     name='edx-opaque-keys',
-    version='2.0.1',
+    version='3.0.0',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}-django{111},py{35,36}-django{20,21,22},quality
+envlist = py35-django{111},py{35,36}-django{20,21,22},quality
 skip_missing_interpreters = True
 
 [testenv]
@@ -10,14 +10,6 @@ deps =
     django22: Django>=2.2,<2.3
     -r{toxinidir}/requirements/django.txt
 commands = pytest --disable-pytest-warnings --nomigrations {posargs}
-
-
-[testenv:pytest-py27]
-basepython = python2.7
-deps =
-    -r{toxinidir}/requirements/test.txt
-commands = pytest --disable-pytest-warnings --ignore=opaque_keys/edx/django {posargs}
-
 
 [testenv:pytest-py35]
 basepython = python3.5


### PR DESCRIPTION
- `DefinitionLocator.version` becomes property rather than method, fixing inheritance warning 
- Fix setup.py to use requirements dir
- Remove unneeded constraints (note: some constraints previously had a trailing single-quote, although it doesn't seem to have caused any harm)
