### PR TITLE
Fix setup.py to use requirements dir; drop max version constraints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
-# Unreleased
+# 2.0.2
 
+* setup.py now properly uses requirements files
+
+# 2.0.1
+
+* Declare support for Python 3.5 and Django 2.2
 
 # 2.0
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include CHANGELOG.rst
+include LICENSE
+include README.rst
+include requirements/base.in
+recursive-include opaque_keys *.html *.png *.gif *js *.css *jpg *jpeg *svg *py

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Core requirements for using this application
 -c constraints.txt
 
-pymongo>=2.7.2,<4.0.0
-six>=1.10.0,<2.0.0'
-stevedore>=0.14.1,<2.0.0'
+pymongo>=2.7.2
+six>=1.10.0
+stevedore>=0.14.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ hypothesis==4.57.1        # via -r requirements/doc.txt
 idna==2.9                 # via -r requirements/doc.txt, -r requirements/travis.txt, requests, urllib3
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
 importlib-metadata==1.5.0  # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.3.1  # via -r requirements/travis.txt, virtualenv
+importlib-resources==1.4.0  # via -r requirements/travis.txt, virtualenv
 ipaddress==1.0.23         # via -r requirements/travis.txt, cryptography, urllib3
 isort==4.3.21             # via -r requirements/doc.txt, pylint
 jinja2==2.11.1            # via -r requirements/doc.txt, sphinx
@@ -88,7 +88,7 @@ tox-battery==0.5.2        # via -r requirements/travis.txt
 tox==3.14.5               # via -r requirements/travis.txt, tox-battery
 typing==3.7.4.1           # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-resources, sphinx
 urllib3[secure]==1.25.8   # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, requests
-virtualenv==20.0.10       # via -r requirements/travis.txt, tox
+virtualenv==20.0.13       # via -r requirements/travis.txt, tox
 wcwidth==0.1.8            # via -r requirements/doc.txt, pytest
 webencodings==0.5.1       # via -r requirements/doc.txt, bleach
 wrapt==1.12.1             # via -r requirements/doc.txt, astroid

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,7 +6,7 @@
 coverage
 ddt
 edx-lint
-hypothesis>=3.84.5
+hypothesis
 mock
 pycodestyle
 pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -19,7 +19,7 @@ enum34==1.1.10            # via cryptography
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests, urllib3
 importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-resources==1.4.0  # via virtualenv
 ipaddress==1.0.23         # via cryptography, urllib3
 packaging==20.3           # via tox
 pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
@@ -37,5 +37,5 @@ tox-battery==0.5.2        # via -r requirements/travis.in
 tox==3.14.5               # via -r requirements/travis.in, tox-battery
 typing==3.7.4.1           # via importlib-resources
 urllib3[secure]==1.25.8   # via coveralls, requests
-virtualenv==20.0.10       # via tox
+virtualenv==20.0.13       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Package metadata for edx-opaque-keys.
+"""
+from io import open
+
 from setuptools import setup, find_packages
+
+def load_requirements(*requirements_paths):
+    """
+    Load all requirements from the specified requirements files.
+
+    Returns:
+        list: Requirements file relative path strings
+    """
+    requirements = set()
+    for path in requirements_paths:
+        with open(path) as reqs:
+            requirements.update(
+                line.split('#')[0].strip() for line in reqs
+                if is_requirement(line.strip())
+            )
+    return list(requirements)
+
+
+def is_requirement(line):
+    """
+    Return True if the requirement line is a package requirement.
+
+    Returns:
+        bool: True if the line is not blank, a comment, a URL, or an included file
+    """
+    return line and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
 
 setup(
     name='edx-opaque-keys',
-    version='2.0.1',
+    version='2.0.2',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[
@@ -18,14 +51,7 @@ setup(
     # We are including the tests because other libraries do use mixins from them.
     packages=find_packages(),
     license='AGPL-3.0',
-    install_requires=[
-        'six>=1.10.0,<2.0.0',
-        'stevedore>=0.14.1,<2.0.0',
-        'pymongo>=2.7.2,<4.0.0'
-    ],
-    extras_require={
-        'django': ['Django>=1.11,<2.0;python_version<"3"', 'Django>=1.11;python_version>"3"']
-    },
+    install_requires=load_requirements('requirements/base.in'),
     entry_points={
         'opaque_keys.testing': [
             'base10 = opaque_keys.tests.test_opaque_keys:Base10Key',


### PR DESCRIPTION
Note that some constraints previously had a trailing single-quote, although it doesn't seem to have caused any harm.

This extracts the requirements fix from https://github.com/edx/opaque-keys/pull/116 but does not drop Python 2.7.