### PR TITLE
Restore [django] extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
   include:
     - python: "3.5"
       env: TOXENV=quality
+    - python: "3.5"
+      env: TOXENV=without-django
 
 install:
   - make requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ matrix:
   include:
     - python: "3.5"
       env: TOXENV=quality
-    - python: "2.7"
-      env: TOXENV=pytest-py27
-    - python: "3.5"
-      env: TOXENV=pytest-py35
 
 install:
   - make requirements

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include CHANGELOG.rst
 include LICENSE
 include README.rst
 include requirements/base.in
+include requirements/django.in
 recursive-include opaque_keys *.html *.png *.gif *js *.css *jpg *jpeg *svg *py

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,10 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --rebuild --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --rebuild --upgrade -o requirements/django.txt requirements/django.in
 	pip-compile --rebuild --upgrade -o requirements/test.txt requirements/test.in
+	pip-compile --rebuild --upgrade -o requirements/django-test.txt requirements/django-test.in
 	pip-compile --rebuild --upgrade -o requirements/doc.txt requirements/doc.in
 	pip-compile --rebuild --upgrade -o requirements/travis.txt requirements/travis.in
 	pip-compile --rebuild --upgrade -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django version for tests
-	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
-	mv requirements/test.tmp requirements/test.txt
+	sed '/^[dD]jango==/d' requirements/django-test.txt > requirements/django-test.tmp
+	mv requirements/django-test.tmp requirements/django-test.txt

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip install -qr requirements/pip-tools.txt
 	pip-compile --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip-compile --rebuild --upgrade -o requirements/base.txt requirements/base.in
-	pip-compile --rebuild --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --rebuild --upgrade -o requirements/django.txt requirements/django.in
+	pip-compile --rebuild --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --rebuild --upgrade -o requirements/doc.txt requirements/doc.in
 	pip-compile --rebuild --upgrade -o requirements/travis.txt requirements/travis.in
 	pip-compile --rebuild --upgrade -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django version for tests
-	sed '/^[dD]jango==/d' requirements/django.txt > requirements/django.tmp
-	mv requirements/django.tmp requirements/django.txt
+	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
+	mv requirements/test.tmp requirements/test.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,6 +25,7 @@ coveralls==1.11.1         # via -r requirements/travis.txt
 cryptography==2.8         # via -r requirements/travis.txt, pyopenssl, urllib3
 ddt==1.3.1                # via -r requirements/doc.txt
 distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
+django==1.11.29           # via -r requirements/doc.txt
 docopt==0.6.2             # via -r requirements/travis.txt, coveralls
 docutils==0.16            # via -r requirements/doc.txt, readme-renderer, sphinx
 edx-lint==1.4.1           # via -r requirements/doc.txt
@@ -72,7 +73,7 @@ pytest-pep8==1.0.6        # via -r requirements/doc.txt
 pytest-pylint==0.14.1     # via -r requirements/doc.txt
 pytest-xdist==1.31.0      # via -r requirements/doc.txt
 pytest==4.6.9             # via -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-pytz==2019.3              # via -r requirements/doc.txt, babel
+pytz==2019.3              # via -r requirements/doc.txt, babel, django
 readme-renderer==25.0     # via -r requirements/doc.txt
 requests==2.23.0          # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, sphinx
 scandir==1.10.0           # via -r requirements/doc.txt, -r requirements/travis.txt, pathlib2
@@ -89,7 +90,7 @@ tox==3.14.5               # via -r requirements/travis.txt, tox-battery
 typing==3.7.4.1           # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-resources, sphinx
 urllib3[secure]==1.25.8   # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, requests
 virtualenv==20.0.13       # via -r requirements/travis.txt, tox
-wcwidth==0.1.8            # via -r requirements/doc.txt, pytest
+wcwidth==0.1.9            # via -r requirements/doc.txt, pytest
 webencodings==0.5.1       # via -r requirements/doc.txt, bleach
 wrapt==1.12.1             # via -r requirements/doc.txt, astroid
 zipp==1.2.0               # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,7 +25,6 @@ coveralls==1.11.1         # via -r requirements/travis.txt
 cryptography==2.8         # via -r requirements/travis.txt, pyopenssl, urllib3
 ddt==1.3.1                # via -r requirements/doc.txt
 distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
-django==1.11.29           # via -r requirements/doc.txt
 docopt==0.6.2             # via -r requirements/travis.txt, coveralls
 docutils==0.16            # via -r requirements/doc.txt, readme-renderer, sphinx
 edx-lint==1.4.1           # via -r requirements/doc.txt
@@ -49,7 +48,7 @@ mccabe==0.6.1             # via -r requirements/doc.txt, pylint
 mock==3.0.5               # via -r requirements/doc.txt
 more-itertools==5.0.0     # via -r requirements/doc.txt, pytest
 packaging==20.3           # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, sphinx, tox
-pathlib2==2.3.5           # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, pytest, pytest-django, virtualenv
+pathlib2==2.3.5           # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, pytest, virtualenv
 pbr==5.4.4                # via -r requirements/doc.txt, stevedore
 pep8==1.7.1               # via -r requirements/doc.txt, pytest-pep8
 pip-tools==4.5.1          # via -r requirements/pip-tools.txt
@@ -67,13 +66,12 @@ pyopenssl==19.1.0         # via -r requirements/travis.txt, urllib3
 pyparsing==2.4.6          # via -r requirements/doc.txt, -r requirements/travis.txt, packaging
 pytest-cache==1.0         # via -r requirements/doc.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/doc.txt
-pytest-django==3.8.0      # via -r requirements/doc.txt
 pytest-forked==1.1.3      # via -r requirements/doc.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/doc.txt
 pytest-pylint==0.14.1     # via -r requirements/doc.txt
 pytest-xdist==1.31.0      # via -r requirements/doc.txt
-pytest==4.6.9             # via -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-pytz==2019.3              # via -r requirements/doc.txt, babel, django
+pytest==4.6.9             # via -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytz==2019.3              # via -r requirements/doc.txt, babel
 readme-renderer==25.0     # via -r requirements/doc.txt
 requests==2.23.0          # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, sphinx
 scandir==1.10.0           # via -r requirements/doc.txt, -r requirements/travis.txt, pathlib2

--- a/requirements/django-test.in
+++ b/requirements/django-test.in
@@ -1,0 +1,7 @@
+# Requirements for test runs, including the django aspects.
+-c constraints.txt
+
+-r test.txt                # Core dependencies
+-r django.txt              # Dependencies for [django] extra
+
+pytest-django              # For testing with the [django] extra

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -4,48 +4,36 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via -r requirements/test.txt, execnet
 astroid==1.6.6            # via -r requirements/test.txt, pylint, pylint-celery
 atomicwrites==1.3.0       # via -r requirements/test.txt, pytest
 attrs==19.3.0             # via -r requirements/test.txt, hypothesis, pytest
-babel==2.8.0              # via sphinx
 backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, astroid, isort, pylint
-bleach==3.1.3             # via readme-renderer
-certifi==2019.11.28       # via requests
-chardet==3.0.4            # via requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.1              # via -r requirements/test.txt, click-log, edx-lint
 configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata, pylint
 contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
 coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/test.txt
-docutils==0.16            # via readme-renderer, sphinx
 edx-lint==1.4.1           # via -r requirements/test.txt
-edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 enum34==1.1.10            # via -r requirements/test.txt, astroid, hypothesis
 execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-xdist
 funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
 futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, isort
 hypothesis==4.57.1        # via -r requirements/test.txt
-idna==2.9                 # via requests
-imagesize==1.2.0          # via sphinx
 importlib-metadata==1.5.0  # via -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
-jinja2==2.11.1            # via sphinx
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
-markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==5.0.0     # via -r requirements/test.txt, pytest
-packaging==20.3           # via -r requirements/test.txt, pytest, sphinx
-pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest
+packaging==20.3           # via -r requirements/test.txt, pytest
+pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest, pytest-django
 pbr==5.4.4                # via -r requirements/test.txt, stevedore
 pep8==1.7.1               # via -r requirements/test.txt, pytest-pep8
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.8.1                 # via -r requirements/test.txt, pytest
 pycodestyle==2.5.0        # via -r requirements/test.txt
-pygments==2.5.2           # via readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==0.11.1     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
@@ -54,28 +42,18 @@ pymongo==3.10.1           # via -r requirements/test.txt
 pyparsing==2.4.6          # via -r requirements/test.txt, packaging
 pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-django==3.8.0      # via -r requirements/django-test.in
 pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
 pytest-pylint==0.14.1     # via -r requirements/test.txt
 pytest-xdist==1.31.0      # via -r requirements/test.txt
-pytest==4.6.9             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-pytz==2019.3              # via babel
-readme-renderer==25.0     # via -r requirements/doc.in
-requests==2.23.0          # via sphinx
+pytest==4.6.9             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytz==2019.3              # via -r requirements/django.txt, django
 scandir==1.10.0           # via -r requirements/test.txt, pathlib2
 singledispatch==3.4.0.3   # via -r requirements/test.txt, astroid, pylint
-six==1.14.0               # via -r requirements/test.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, readme-renderer, singledispatch, sphinx, stevedore
-snowballstemmer==2.0.0    # via sphinx
+six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, singledispatch, stevedore
 sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
-sphinx==1.8.5             # via -r requirements/doc.in, edx-sphinx-theme
-sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.32.0         # via -r requirements/test.txt
-typing==3.7.4.1           # via sphinx
-urllib3==1.25.8           # via requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
-webencodings==0.5.1       # via bleach
 wrapt==1.12.1             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/django.in
+++ b/requirements/django.in
@@ -1,6 +1,8 @@
 # Requirements for [django] extra, not including base deps
 -c constraints.txt
--c base.txt                # Match resolved versions of core dependencies
+
+# Match resolved versions of core dependencies (doesn't actually pull them in)
+-c base.txt
 
 
 Django>=1.11

--- a/requirements/django.in
+++ b/requirements/django.in
@@ -1,6 +1,6 @@
-# Requirements for test runs utilizing Django support
+# Requirements for [django] extra, not including base deps
 -c constraints.txt
+-c base.txt                # Match resolved versions of core dependencies
 
--r test.txt               # Non-Django testing dependencies
 
-pytest-django
+Django>=1.11

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -4,55 +4,5 @@
 #
 #    make upgrade
 #
-apipkg==1.5               # via -r requirements/test.txt, execnet
-astroid==1.6.6            # via -r requirements/test.txt, pylint, pylint-celery
-atomicwrites==1.3.0       # via -r requirements/test.txt, pytest
-attrs==19.3.0             # via -r requirements/test.txt, hypothesis, pytest
-backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, astroid, isort, pylint
-click-log==0.3.2          # via -r requirements/test.txt, edx-lint
-click==7.1.1              # via -r requirements/test.txt, click-log, edx-lint
-configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
-coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
-ddt==1.3.1                # via -r requirements/test.txt
-edx-lint==1.4.1           # via -r requirements/test.txt
-enum34==1.1.10            # via -r requirements/test.txt, astroid, hypothesis
-execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-xdist
-funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, isort
-hypothesis==4.57.1        # via -r requirements/test.txt
-importlib-metadata==1.5.0  # via -r requirements/test.txt, pluggy, pytest
-isort==4.3.21             # via -r requirements/test.txt, pylint
-lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
-mccabe==0.6.1             # via -r requirements/test.txt, pylint
-mock==3.0.5               # via -r requirements/test.txt
-more-itertools==5.0.0     # via -r requirements/test.txt, pytest
-packaging==20.3           # via -r requirements/test.txt, pytest
-pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest, pytest-django
-pbr==5.4.4                # via -r requirements/test.txt, stevedore
-pep8==1.7.1               # via -r requirements/test.txt, pytest-pep8
-pluggy==0.13.1            # via -r requirements/test.txt, pytest
-py==1.8.1                 # via -r requirements/test.txt, pytest
-pycodestyle==2.5.0        # via -r requirements/test.txt
-pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==0.11.1     # via -r requirements/test.txt, edx-lint
-pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==1.9.5             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
-pymongo==3.10.1           # via -r requirements/test.txt
-pyparsing==2.4.6          # via -r requirements/test.txt, packaging
-pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
-pytest-cov==2.8.1         # via -r requirements/test.txt
-pytest-django==3.8.0      # via -r requirements/django.in
-pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
-pytest-pep8==1.0.6        # via -r requirements/test.txt
-pytest-pylint==0.14.1     # via -r requirements/test.txt
-pytest-xdist==1.31.0      # via -r requirements/test.txt
-pytest==4.6.9             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-scandir==1.10.0           # via -r requirements/test.txt, pathlib2
-singledispatch==3.4.0.3   # via -r requirements/test.txt, astroid, pylint
-six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, singledispatch, stevedore
-sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
-stevedore==1.32.0         # via -r requirements/test.txt
-wcwidth==0.1.8            # via -r requirements/test.txt, pytest
-wrapt==1.12.1             # via -r requirements/test.txt, astroid
-zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
+django==1.11.29           # via -r requirements/django.in
+pytz==2019.3              # via django

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -1,7 +1,7 @@
 # Requirements for documentation generation and validation
 -c constraints.txt
 
--r django.txt             # Core and testing dependencies for this package
+-r test.txt               # Core and testing dependencies for this package
 
 edx_sphinx_theme          # edX theme for Sphinx output
 readme_renderer           # Validates README.rst for usage on PyPI

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,78 +5,79 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-apipkg==1.5               # via -r requirements/django.txt, execnet
-astroid==1.6.6            # via -r requirements/django.txt, pylint, pylint-celery
-atomicwrites==1.3.0       # via -r requirements/django.txt, pytest
-attrs==19.3.0             # via -r requirements/django.txt, hypothesis, pytest
+apipkg==1.5               # via -r requirements/test.txt, execnet
+astroid==1.6.6            # via -r requirements/test.txt, pylint, pylint-celery
+atomicwrites==1.3.0       # via -r requirements/test.txt, pytest
+attrs==19.3.0             # via -r requirements/test.txt, hypothesis, pytest
 babel==2.8.0              # via sphinx
-backports.functools-lru-cache==1.6.1  # via -r requirements/django.txt, astroid, isort, pylint
+backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, astroid, isort, pylint
 bleach==3.1.3             # via readme-renderer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-click-log==0.3.2          # via -r requirements/django.txt, edx-lint
-click==7.1.1              # via -r requirements/django.txt, click-log, edx-lint
-configparser==4.0.2       # via -r requirements/django.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/django.txt, importlib-metadata, zipp
-coverage==5.0.4           # via -r requirements/django.txt, pytest-cov
-ddt==1.3.1                # via -r requirements/django.txt
+click-log==0.3.2          # via -r requirements/test.txt, edx-lint
+click==7.1.1              # via -r requirements/test.txt, click-log, edx-lint
+configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata, pylint
+contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
+coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
+ddt==1.3.1                # via -r requirements/test.txt
+django==1.11.29           # via -r requirements/test.txt
 docutils==0.16            # via readme-renderer, sphinx
-edx-lint==1.4.1           # via -r requirements/django.txt
+edx-lint==1.4.1           # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-enum34==1.1.10            # via -r requirements/django.txt, astroid, hypothesis
-execnet==1.7.1            # via -r requirements/django.txt, pytest-cache, pytest-xdist
-funcsigs==1.0.2           # via -r requirements/django.txt, mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/django.txt, isort
-hypothesis==4.57.1        # via -r requirements/django.txt
+enum34==1.1.10            # via -r requirements/test.txt, astroid, hypothesis
+execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-xdist
+funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, isort
+hypothesis==4.57.1        # via -r requirements/test.txt
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.5.0  # via -r requirements/django.txt, pluggy, pytest
-isort==4.3.21             # via -r requirements/django.txt, pylint
+importlib-metadata==1.5.0  # via -r requirements/test.txt, pluggy, pytest
+isort==4.3.21             # via -r requirements/test.txt, pylint
 jinja2==2.11.1            # via sphinx
-lazy-object-proxy==1.4.3  # via -r requirements/django.txt, astroid
+lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via -r requirements/django.txt, pylint
-mock==3.0.5               # via -r requirements/django.txt
-more-itertools==5.0.0     # via -r requirements/django.txt, pytest
-packaging==20.3           # via -r requirements/django.txt, pytest, sphinx
-pathlib2==2.3.5           # via -r requirements/django.txt, importlib-metadata, pytest, pytest-django
-pbr==5.4.4                # via -r requirements/django.txt, stevedore
-pep8==1.7.1               # via -r requirements/django.txt, pytest-pep8
-pluggy==0.13.1            # via -r requirements/django.txt, pytest
-py==1.8.1                 # via -r requirements/django.txt, pytest
-pycodestyle==2.5.0        # via -r requirements/django.txt
+mccabe==0.6.1             # via -r requirements/test.txt, pylint
+mock==3.0.5               # via -r requirements/test.txt
+more-itertools==5.0.0     # via -r requirements/test.txt, pytest
+packaging==20.3           # via -r requirements/test.txt, pytest, sphinx
+pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest, pytest-django
+pbr==5.4.4                # via -r requirements/test.txt, stevedore
+pep8==1.7.1               # via -r requirements/test.txt, pytest-pep8
+pluggy==0.13.1            # via -r requirements/test.txt, pytest
+py==1.8.1                 # via -r requirements/test.txt, pytest
+pycodestyle==2.5.0        # via -r requirements/test.txt
 pygments==2.5.2           # via readme-renderer, sphinx
-pylint-celery==0.3        # via -r requirements/django.txt, edx-lint
-pylint-django==0.11.1     # via -r requirements/django.txt, edx-lint
-pylint-plugin-utils==0.6  # via -r requirements/django.txt, pylint-celery, pylint-django
-pylint==1.9.5             # via -r requirements/django.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
-pymongo==3.10.1           # via -r requirements/django.txt
-pyparsing==2.4.6          # via -r requirements/django.txt, packaging
-pytest-cache==1.0         # via -r requirements/django.txt, pytest-pep8
-pytest-cov==2.8.1         # via -r requirements/django.txt
-pytest-django==3.8.0      # via -r requirements/django.txt
-pytest-forked==1.1.3      # via -r requirements/django.txt, pytest-xdist
-pytest-pep8==1.0.6        # via -r requirements/django.txt
-pytest-pylint==0.14.1     # via -r requirements/django.txt
-pytest-xdist==1.31.0      # via -r requirements/django.txt
-pytest==4.6.9             # via -r requirements/django.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-pytz==2019.3              # via babel
+pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
+pylint-django==0.11.1     # via -r requirements/test.txt, edx-lint
+pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
+pylint==1.9.5             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pymongo==3.10.1           # via -r requirements/test.txt
+pyparsing==2.4.6          # via -r requirements/test.txt, packaging
+pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
+pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-django==3.8.0      # via -r requirements/test.txt
+pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
+pytest-pep8==1.0.6        # via -r requirements/test.txt
+pytest-pylint==0.14.1     # via -r requirements/test.txt
+pytest-xdist==1.31.0      # via -r requirements/test.txt
+pytest==4.6.9             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytz==2019.3              # via -r requirements/test.txt, babel, django
 readme-renderer==25.0     # via -r requirements/doc.in
 requests==2.23.0          # via sphinx
-scandir==1.10.0           # via -r requirements/django.txt, pathlib2
-singledispatch==3.4.0.3   # via -r requirements/django.txt, astroid, pylint
-six==1.14.0               # via -r requirements/django.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, readme-renderer, singledispatch, sphinx, stevedore
+scandir==1.10.0           # via -r requirements/test.txt, pathlib2
+singledispatch==3.4.0.3   # via -r requirements/test.txt, astroid, pylint
+six==1.14.0               # via -r requirements/test.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, readme-renderer, singledispatch, sphinx, stevedore
 snowballstemmer==2.0.0    # via sphinx
-sortedcontainers==2.1.0   # via -r requirements/django.txt, hypothesis
+sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
 sphinx==1.8.5             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-websupport==1.1.2  # via sphinx
-stevedore==1.32.0         # via -r requirements/django.txt
+stevedore==1.32.0         # via -r requirements/test.txt
 typing==3.7.4.1           # via sphinx
 urllib3==1.25.8           # via requests
-wcwidth==0.1.8            # via -r requirements/django.txt, pytest
+wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
-wrapt==1.12.1             # via -r requirements/django.txt, astroid
-zipp==1.2.0               # via -r requirements/django.txt, importlib-metadata
+wrapt==1.12.1             # via -r requirements/test.txt, astroid
+zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,7 +1,8 @@
 # Requirements for test runs.
 -c constraints.txt
 
--r base.txt               # Core dependencies for this package
+-r base.txt                # Core dependencies
+-r django.txt              # Dependencies for [django] extra
 
 coverage
 ddt
@@ -15,3 +16,5 @@ pytest-pep8
 pytest-pylint
 pytest-xdist
 singledispatch
+
+pytest-django              # For testing with the [django] extra

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,8 +1,7 @@
-# Requirements for test runs.
+# Requirements for test runs, just testing the base functionality.
 -c constraints.txt
 
 -r base.txt                # Core dependencies
--r django.txt              # Dependencies for [django] extra
 
 coverage
 ddt
@@ -16,5 +15,3 @@ pytest-pep8
 pytest-pylint
 pytest-xdist
 singledispatch
-
-pytest-django              # For testing with the [django] extra

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,7 +28,7 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==5.0.0     # via pytest
 packaging==20.3           # via pytest
-pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
+pathlib2==2.3.5           # via importlib-metadata, pytest
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
@@ -42,13 +42,11 @@ pymongo==3.10.1           # via -r requirements/base.txt
 pyparsing==2.4.6          # via packaging
 pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.in
-pytest-django==3.8.0      # via -r requirements/test.in
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.in
 pytest-pylint==0.14.1     # via -r requirements/test.in
 pytest-xdist==1.31.0      # via -r requirements/test.in
-pytest==4.6.9             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-pytz==2019.3              # via -r requirements/django.txt, django
+pytest==4.6.9             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 scandir==1.10.0           # via pathlib2
 singledispatch==3.4.0.3   # via -r requirements/test.in, astroid, pylint
 six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, singledispatch, stevedore

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,7 +28,7 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
 more-itertools==5.0.0     # via pytest
 packaging==20.3           # via pytest
-pathlib2==2.3.5           # via importlib-metadata, pytest
+pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
@@ -42,16 +42,18 @@ pymongo==3.10.1           # via -r requirements/base.txt
 pyparsing==2.4.6          # via packaging
 pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-django==3.8.0      # via -r requirements/test.in
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.in
 pytest-pylint==0.14.1     # via -r requirements/test.in
 pytest-xdist==1.31.0      # via -r requirements/test.in
-pytest==4.6.9             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==4.6.9             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytz==2019.3              # via -r requirements/django.txt, django
 scandir==1.10.0           # via pathlib2
 singledispatch==3.4.0.3   # via -r requirements/test.in, astroid, pylint
 six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, singledispatch, stevedore
 sortedcontainers==2.1.0   # via hypothesis
 stevedore==1.32.0         # via -r requirements/base.txt
-wcwidth==0.1.8            # via pytest
+wcwidth==0.1.9            # via pytest
 wrapt==1.12.1             # via astroid
 zipp==1.2.0               # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ setup(
     packages=find_packages(),
     license='AGPL-3.0',
     install_requires=load_requirements('requirements/base.in'),
+    extras_require={
+        'django': load_requirements('requirements/django.in')
+    },
     entry_points={
         'opaque_keys.testing': [
             'base10 = opaque_keys.tests.test_opaque_keys:Base10Key',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}-django{111},py{35,36}-django{20,21,22},quality
+envlist = py{27,35}-django{111},py35-django{20,21,22},quality
 skip_missing_interpreters = True
 
 [testenv]
@@ -8,22 +8,8 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
-    -r{toxinidir}/requirements/django.txt
+    -r{toxinidir}/requirements/test.txt
 commands = pytest --disable-pytest-warnings --nomigrations {posargs}
-
-
-[testenv:pytest-py27]
-basepython = python2.7
-deps =
-    -r{toxinidir}/requirements/test.txt
-commands = pytest --disable-pytest-warnings --ignore=opaque_keys/edx/django {posargs}
-
-
-[testenv:pytest-py35]
-basepython = python3.5
-deps =
-    -r{toxinidir}/requirements/test.txt
-commands = pytest --disable-pytest-warnings --ignore=opaque_keys/edx/django {posargs}
 
 [testenv:quality]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}-django{111},py35-django{20,21,22},quality
+envlist = py{27,35}-django{111},py35-django{20,21,22},quality,without-django
 skip_missing_interpreters = True
 
 [testenv]
@@ -8,8 +8,13 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
-    -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/django-test.txt
 commands = pytest --disable-pytest-warnings --nomigrations {posargs}
+
+[testenv:without-django]
+deps =
+    -r{toxinidir}/requirements/test.txt
+commands = pytest --disable-pytest-warnings --ignore=opaque_keys/edx/django {posargs}
 
 [testenv:quality]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py{27,35}-django{111},py35-django{20,21,22},quality,without-django
 skip_missing_interpreters = True
 
+# Run most tests with the django functionality included
 [testenv]
 deps =
     django111: Django>=1.11,<2.0
@@ -11,6 +12,9 @@ deps =
     -r{toxinidir}/requirements/django-test.txt
 commands = pytest --disable-pytest-warnings --nomigrations {posargs}
 
+# Run a subset of the tests that don't use django functionality—and
+# don't include the django dependency when doing it. This helps ensure
+# that only `opaque_keys/edx/django` uses that django dependency.
 [testenv:without-django]
 deps =
     -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
This also changes the purpose of `django.in` from being a "core + django + django" deps collection to just being the extra deps required for django support.