### PR TITLE
BOM-1538 : Add Python 3.8 to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - python: 3.8
 
 install:
+  - pip install pip==20.0.2
   - make requirements
   - pip install coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ env:
   - TOXENV=quality
   - TOXENV=without-django
 
-matrix:
-  allow_failures:
-    - python: 3.8
-
 install:
   - pip install pip==20.0.2
   - make requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,16 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
+  - "3.8"
 
 env:
-  - TOXENV=django111
-  - TOXENV=django20
-  - TOXENV=django21
   - TOXENV=django22
+  - TOXENV=quality
+  - TOXENV=without-django
 
 matrix:
-  exclude:
-    - python: "2.7"
-      env: TOXENV=django20
-    - python: "2.7"
-      env: TOXENV=django21
-    - python: "2.7"
-      env: TOXENV=django22
-  include:
-    - python: "3.5"
-      env: TOXENV=quality
-    - python: "3.5"
-      env: TOXENV=without-django
+  allow_failures:
+    - python: 3.8
 
 install:
   - make requirements
@@ -38,6 +27,6 @@ deploy:
   on:
     tags: true
     python: "3.5"
-    condition: "$TOXENV = django111"
+    condition: "$TOXENV = django22"
     distributions: sdist bdist_wheel
     repo: edx/opaque-keys

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -23,7 +23,7 @@ from opaque_keys.edx.keys import BlockTypeKey, CourseKey, LearningContextKey, Us
 log = logging.getLogger(__name__)
 
 
-class _Creator(object):
+class _Creator:
     """
     DO NOT REUSE THIS CLASS. Provided for backwards compatibility only!
 
@@ -42,7 +42,7 @@ class _Creator(object):
 
 
 # pylint: disable=missing-docstring,unused-argument
-class CreatorMixin(object):
+class CreatorMixin:
     """
     Mixin class to provide SubfieldBase functionality to django fields.
     See: https://docs.djangoproject.com/en/1.11/releases/1.8/#subfieldbase

--- a/opaque_keys/edx/django/tests/models.py
+++ b/opaque_keys/edx/django/tests/models.py
@@ -16,7 +16,7 @@ from opaque_keys.edx.django.models import (
 )
 
 
-class Container(object):
+class Container:
     """A simple wrapper class for string-like objects."""
 
     def __init__(self, text):

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -107,7 +107,7 @@ class DefinitionKey(OpaqueKey):
         raise NotImplementedError()
 
 
-class CourseObjectMixin(object):
+class CourseObjectMixin:
     """
     An abstract :class:`opaque_keys.OpaqueKey` mixin
     for keys that belong to courses.

--- a/opaque_keys/edx/locations.py
+++ b/opaque_keys/edx/locations.py
@@ -65,7 +65,7 @@ class SlashSeparatedCourseKey(CourseLocator):
         )
 
 
-class LocationBase(object):
+class LocationBase:
     """Deprecated. Base class for :class:`Location` and :class:`AssetLocation`"""
 
     DEPRECATED_TAG = None  # Subclasses should define what DEPRECATED_TAG is

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -9,7 +9,6 @@ import logging
 import re
 from uuid import UUID
 import warnings
-from abc import abstractproperty
 
 from bson.errors import InvalidId
 from bson.objectid import ObjectId
@@ -23,7 +22,7 @@ from opaque_keys.edx.keys import AssetKey, CourseKey, DefinitionKey, LearningCon
 log = logging.getLogger(__name__)
 
 
-class LocalId(object):
+class LocalId:
     """
     Class for local ids for non-persisted xblocks (which can have hardcoded block_ids if necessary)
     """
@@ -48,7 +47,7 @@ class Locator(OpaqueKey):
     ALLOWED_ID_CHARS = r'[\w\-~.:]'
     DEPRECATED_ALLOWED_ID_CHARS = r'[\w\-~.:%]'
 
-    @abstractproperty
+    @property
     def version(self):  # pragma: no cover
         """
         Returns the ObjectId referencing this specific location.
@@ -72,7 +71,7 @@ class Locator(OpaqueKey):
             raise InvalidKeyError(cls, u'"%s" is not a valid version_guid' % value)
 
 
-class CheckFieldMixin(object):
+class CheckFieldMixin:
     """
     Mixin that provides handy methods for checking field types/values.
     """
@@ -1220,6 +1219,7 @@ class DefinitionLocator(Locator, DefinitionKey):
 
         return cls(**{key: parse.get(key) for key in cls.KEY_FIELDS})
 
+    @property
     def version(self):
         """
         Returns the ObjectId referencing this specific location.
@@ -1227,7 +1227,7 @@ class DefinitionLocator(Locator, DefinitionKey):
         return self.definition_id
 
 
-class VersionTree(object):
+class VersionTree:
     """
     Holds trees of Locators to represent version histories.
     """

--- a/opaque_keys/edx/tests/test_locators.py
+++ b/opaque_keys/edx/tests/test_locators.py
@@ -40,7 +40,7 @@ class DefinitionLocatorTests(TestCase):
     def test_description_locator_version(self):
         object_id = '{:024x}'.format(random.randrange(16 ** 24))
         definition_locator = DefinitionLocator('html', object_id)
-        self.assertEqual(object_id, str(definition_locator.version()))
+        self.assertEqual(object_id, str(definition_locator.version))
 
 
 @ddt.ddt

--- a/opaque_keys/tests/strategies.py
+++ b/opaque_keys/tests/strategies.py
@@ -2,13 +2,12 @@
 ``hypothesis`` strategies for generating OpaqueKey objects.
 """
 
-from functools import update_wrapper
+from functools import singledispatch, update_wrapper
 import string
 from six import text_type
 
 from hypothesis import strategies, assume
 from hypothesis.strategies._internal.core import cacheable
-from singledispatch import singledispatch
 
 from opaque_keys.edx.block_types import BlockTypeKeyV1, XBLOCK_V1, XMODULE_V1
 from opaque_keys.edx.asides import (

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,5 +12,5 @@
 # Look into https://github.com/pytest-dev/pytest/issues/6925
 pytest<=5.3
 
-# version > 0.15 requires pytest >= 5.4
+# version >= 0.16 requires pytest >= 5.4
 pytest-pylint<0.16

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,6 +8,6 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# These packages are backports which can only be installed on Python 2.7
-functools32 ; python_version == "2.7"
-futures ; python_version == "2.7"
+# pytest command fails if pytest > 5.3 is used
+# Look into https://github.com/pytest-dev/pytest/issues/6925
+pytest<=5.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,4 +13,4 @@
 pytest<=5.3
 
 # version > 0.15 requires pytest >= 5.4
-pytest-pylint<0.16.1
+pytest-pylint<0.16

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,3 +7,10 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+
+# pytest command fails if pytest > 5.3 is used
+# Look into https://github.com/pytest-dev/pytest/issues/6925
+pytest<=5.3
+
+# version > 0.15 requires pytest >= 5.4
+pytest-pylint<0.16.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,7 +7,3 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
-
-# pytest command fails if pytest > 5.3 is used
-# Look into https://github.com/pytest-dev/pytest/issues/6925
-pytest<=5.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -56,7 +56,7 @@ pytest-cache==1.0         # via -r requirements/doc.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/doc.txt
 pytest-forked==1.1.3      # via -r requirements/doc.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/doc.txt
-pytest-pylint==0.16.0     # via -c requirements/constraints.txt, -r requirements/doc.txt
+pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements/doc.txt
 pytest-xdist==1.31.0      # via -r requirements/doc.txt
 pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via -r requirements/doc.txt, babel
@@ -74,7 +74,7 @@ sphinxcontrib-jsmath==1.0.1  # via -r requirements/doc.txt, sphinx
 sphinxcontrib-qthelp==1.0.3  # via -r requirements/doc.txt, sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/doc.txt, sphinx
 stevedore==1.32.0         # via -r requirements/doc.txt
-toml==0.10.0              # via -r requirements/doc.txt, -r requirements/travis.txt, pytest-pylint, tox
+toml==0.10.0              # via -r requirements/travis.txt, tox
 tox-battery==0.5.2        # via -r requirements/travis.txt
 tox==3.14.6               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/doc.txt, astroid

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -56,9 +56,9 @@ pytest-cache==1.0         # via -r requirements/doc.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/doc.txt
 pytest-forked==1.1.3      # via -r requirements/doc.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/doc.txt
-pytest-pylint==0.16.1     # via -r requirements/doc.txt
+pytest-pylint==0.16.0     # via -c requirements/constraints.txt, -r requirements/doc.txt
 pytest-xdist==1.31.0      # via -r requirements/doc.txt
-pytest==5.4.1             # via -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via -r requirements/doc.txt, babel
 readme-renderer==26.0     # via -r requirements/doc.txt
 requests==2.23.0          # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,90 +7,82 @@
 alabaster==0.7.12         # via -r requirements/doc.txt, sphinx
 apipkg==1.5               # via -r requirements/doc.txt, execnet
 appdirs==1.4.3            # via -r requirements/travis.txt, virtualenv
-astroid==1.6.6            # via -r requirements/doc.txt, pylint, pylint-celery
-atomicwrites==1.3.0       # via -r requirements/doc.txt, pytest
+astroid==2.3.3            # via -r requirements/doc.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/doc.txt, hypothesis, pytest
 babel==2.8.0              # via -r requirements/doc.txt, sphinx
-backports.functools-lru-cache==1.6.1  # via -r requirements/doc.txt, astroid, isort, pylint
 bleach==3.1.4             # via -r requirements/doc.txt, readme-renderer
-certifi==2020.4.5.1       # via -r requirements/doc.txt, -r requirements/travis.txt, requests, urllib3
-cffi==1.14.0              # via -r requirements/travis.txt, cryptography
+certifi==2020.4.5.1       # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/doc.txt, edx-lint
 click==7.1.1              # via -r requirements/doc.txt, -r requirements/pip-tools.txt, click-log, edx-lint, pip-tools
-configparser==4.0.2       # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, virtualenv, zipp
 coverage==5.1             # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, pytest-cov
-coveralls==1.11.1         # via -r requirements/travis.txt
-cryptography==2.9.2       # via -r requirements/travis.txt, pyopenssl, urllib3
+coveralls==2.0.0          # via -r requirements/travis.txt
 ddt==1.3.1                # via -r requirements/doc.txt
 distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
 docopt==0.6.2             # via -r requirements/travis.txt, coveralls
 docutils==0.16            # via -r requirements/doc.txt, readme-renderer, sphinx
 edx-lint==1.4.1           # via -r requirements/doc.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.txt
-enum34==1.1.10            # via -r requirements/doc.txt, -r requirements/travis.txt, astroid, cryptography, hypothesis
 execnet==1.7.1            # via -r requirements/doc.txt, pytest-cache, pytest-xdist
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
-funcsigs==1.0.2           # via -r requirements/doc.txt, mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/doc.txt, isort
-hypothesis==4.57.1        # via -r requirements/doc.txt
-idna==2.9                 # via -r requirements/doc.txt, -r requirements/travis.txt, requests, urllib3
+hypothesis==5.10.4        # via -r requirements/doc.txt
+idna==2.9                 # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
 importlib-metadata==1.6.0  # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-resources, pluggy, pytest, tox, virtualenv
 importlib-resources==1.4.0  # via -r requirements/travis.txt, virtualenv
-ipaddress==1.0.23         # via -r requirements/travis.txt, cryptography, urllib3
 isort==4.3.21             # via -r requirements/doc.txt, pylint
 jinja2==2.11.2            # via -r requirements/doc.txt, sphinx
 lazy-object-proxy==1.4.3  # via -r requirements/doc.txt, astroid
 markupsafe==1.1.1         # via -r requirements/doc.txt, jinja2
 mccabe==0.6.1             # via -r requirements/doc.txt, pylint
 mock==3.0.5               # via -r requirements/doc.txt
-more-itertools==5.0.0     # via -r requirements/doc.txt, pytest
+more-itertools==8.2.0     # via -r requirements/doc.txt, pytest
 packaging==20.3           # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, sphinx, tox
-pathlib2==2.3.5           # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources, pytest, virtualenv
+pathlib2==2.3.5           # via -r requirements/doc.txt, pytest
 pbr==5.4.5                # via -r requirements/doc.txt, stevedore
 pep8==1.7.1               # via -r requirements/doc.txt, pytest-pep8
 pip-tools==5.0.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, tox
 py==1.8.1                 # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.5.0        # via -r requirements/doc.txt
-pycparser==2.20           # via -r requirements/travis.txt, cffi
-pygments==2.5.2           # via -r requirements/doc.txt, readme-renderer, sphinx
+pygments==2.6.1           # via -r requirements/doc.txt, readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/doc.txt, edx-lint
-pylint-django==0.11.1     # via -r requirements/doc.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/doc.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/doc.txt, pylint-celery, pylint-django
-pylint==1.9.5             # via -r requirements/doc.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pylint==2.4.2             # via -r requirements/doc.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
 pymongo==3.10.1           # via -r requirements/doc.txt
-pyopenssl==19.1.0         # via -r requirements/travis.txt, urllib3
 pyparsing==2.4.7          # via -r requirements/doc.txt, -r requirements/travis.txt, packaging
 pytest-cache==1.0         # via -r requirements/doc.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/doc.txt
 pytest-forked==1.1.3      # via -r requirements/doc.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/doc.txt
-pytest-pylint==0.14.1     # via -r requirements/doc.txt
+pytest-pylint==0.15.1     # via -r requirements/doc.txt
 pytest-xdist==1.31.0      # via -r requirements/doc.txt
-pytest==4.6.9             # via -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2019.3              # via -r requirements/doc.txt, babel
 readme-renderer==26.0     # via -r requirements/doc.txt
 requests==2.23.0          # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, sphinx
-scandir==1.10.0           # via -r requirements/doc.txt, -r requirements/travis.txt, pathlib2
-singledispatch==3.4.0.3   # via -r requirements/doc.txt, -r requirements/travis.txt, astroid, importlib-resources, pylint
-six==1.14.0               # via -r requirements/doc.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, bleach, cryptography, edx-lint, edx-sphinx-theme, mock, more-itertools, packaging, pathlib2, pip-tools, pylint, pyopenssl, pytest, pytest-pylint, pytest-xdist, readme-renderer, singledispatch, sphinx, stevedore, tox, virtualenv
+singledispatch==3.4.0.3   # via -r requirements/doc.txt
+six==1.14.0               # via -r requirements/doc.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pip-tools, pytest-xdist, readme-renderer, singledispatch, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/doc.txt, sphinx
 sortedcontainers==2.1.0   # via -r requirements/doc.txt, hypothesis
-sphinx==1.8.5             # via -r requirements/doc.txt, edx-sphinx-theme
-sphinxcontrib-websupport==1.1.2  # via -r requirements/doc.txt, sphinx
+sphinx==3.0.2             # via -r requirements/doc.txt, edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-devhelp==1.0.2  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-jsmath==1.0.1  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-qthelp==1.0.3  # via -r requirements/doc.txt, sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/doc.txt, sphinx
 stevedore==1.32.0         # via -r requirements/doc.txt
 toml==0.10.0              # via -r requirements/travis.txt, tox
 tox-battery==0.5.2        # via -r requirements/travis.txt
 tox==3.14.6               # via -r requirements/travis.txt, tox-battery
-typing==3.7.4.1           # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-resources, sphinx
-urllib3[secure]==1.25.9   # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, requests
+typed-ast==1.4.1          # via -r requirements/doc.txt, astroid
+urllib3==1.25.9           # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 virtualenv==20.0.18       # via -r requirements/travis.txt, tox
 wcwidth==0.1.9            # via -r requirements/doc.txt, pytest
 webencodings==0.5.1       # via -r requirements/doc.txt, bleach
-wrapt==1.12.1             # via -r requirements/doc.txt, astroid
+wrapt==1.11.2             # via -r requirements/doc.txt, astroid
 zipp==1.2.0               # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -62,8 +62,7 @@ pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements
 pytz==2020.1              # via -r requirements/doc.txt, babel
 readme-renderer==26.0     # via -r requirements/doc.txt
 requests==2.23.0          # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, sphinx
-singledispatch==3.4.0.3   # via -r requirements/doc.txt
-six==1.14.0               # via -r requirements/doc.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pip-tools, pytest-xdist, readme-renderer, singledispatch, stevedore, tox, virtualenv
+six==1.14.0               # via -r requirements/doc.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pip-tools, pytest-xdist, readme-renderer, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/doc.txt, sphinx
 sortedcontainers==2.1.0   # via -r requirements/doc.txt, hypothesis
 sphinx==3.0.3             # via -r requirements/doc.txt, edx-sphinx-theme

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ bleach==3.1.4             # via -r requirements/doc.txt, readme-renderer
 certifi==2020.4.5.1       # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/doc.txt, edx-lint
-click==7.1.1              # via -r requirements/doc.txt, -r requirements/pip-tools.txt, click-log, edx-lint, pip-tools
+click==7.1.2              # via -r requirements/doc.txt, -r requirements/pip-tools.txt, click-log, edx-lint, pip-tools
 coverage==5.1             # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, pytest-cov
 coveralls==2.0.0          # via -r requirements/travis.txt
 ddt==1.3.1                # via -r requirements/doc.txt
@@ -29,7 +29,7 @@ hypothesis==5.10.4        # via -r requirements/doc.txt
 idna==2.9                 # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
 importlib-metadata==1.6.0  # via -r requirements/doc.txt, -r requirements/travis.txt, importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.4.0  # via -r requirements/travis.txt, virtualenv
+importlib-resources==1.5.0  # via -r requirements/travis.txt, virtualenv
 isort==4.3.21             # via -r requirements/doc.txt, pylint
 jinja2==2.11.2            # via -r requirements/doc.txt, sphinx
 lazy-object-proxy==1.4.3  # via -r requirements/doc.txt, astroid
@@ -41,7 +41,7 @@ packaging==20.3           # via -r requirements/doc.txt, -r requirements/travis.
 pathlib2==2.3.5           # via -r requirements/doc.txt, pytest
 pbr==5.4.5                # via -r requirements/doc.txt, stevedore
 pep8==1.7.1               # via -r requirements/doc.txt, pytest-pep8
-pip-tools==5.0.0          # via -r requirements/pip-tools.txt
+pip-tools==5.1.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, tox
 py==1.8.1                 # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.5.0        # via -r requirements/doc.txt
@@ -56,17 +56,17 @@ pytest-cache==1.0         # via -r requirements/doc.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/doc.txt
 pytest-forked==1.1.3      # via -r requirements/doc.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/doc.txt
-pytest-pylint==0.15.1     # via -r requirements/doc.txt
+pytest-pylint==0.16.1     # via -r requirements/doc.txt
 pytest-xdist==1.31.0      # via -r requirements/doc.txt
-pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-pytz==2019.3              # via -r requirements/doc.txt, babel
+pytest==5.4.1             # via -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytz==2020.1              # via -r requirements/doc.txt, babel
 readme-renderer==26.0     # via -r requirements/doc.txt
 requests==2.23.0          # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, sphinx
 singledispatch==3.4.0.3   # via -r requirements/doc.txt
 six==1.14.0               # via -r requirements/doc.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pip-tools, pytest-xdist, readme-renderer, singledispatch, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/doc.txt, sphinx
 sortedcontainers==2.1.0   # via -r requirements/doc.txt, hypothesis
-sphinx==3.0.2             # via -r requirements/doc.txt, edx-sphinx-theme
+sphinx==3.0.3             # via -r requirements/doc.txt, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via -r requirements/doc.txt, sphinx
 sphinxcontrib-devhelp==1.0.2  # via -r requirements/doc.txt, sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via -r requirements/doc.txt, sphinx
@@ -74,7 +74,7 @@ sphinxcontrib-jsmath==1.0.1  # via -r requirements/doc.txt, sphinx
 sphinxcontrib-qthelp==1.0.3  # via -r requirements/doc.txt, sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/doc.txt, sphinx
 stevedore==1.32.0         # via -r requirements/doc.txt
-toml==0.10.0              # via -r requirements/travis.txt, tox
+toml==0.10.0              # via -r requirements/doc.txt, -r requirements/travis.txt, pytest-pylint, tox
 tox-battery==0.5.2        # via -r requirements/travis.txt
 tox==3.14.6               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/doc.txt, astroid

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -5,39 +5,32 @@
 #    make upgrade
 #
 apipkg==1.5               # via -r requirements/test.txt, execnet
-astroid==1.6.6            # via -r requirements/test.txt, pylint, pylint-celery
-atomicwrites==1.3.0       # via -r requirements/test.txt, pytest
+astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, hypothesis, pytest
-backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, astroid, isort, pylint
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.1              # via -r requirements/test.txt, click-log, edx-lint
-configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/test.txt
 edx-lint==1.4.1           # via -r requirements/test.txt
-enum34==1.1.10            # via -r requirements/test.txt, astroid, hypothesis
 execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-xdist
-funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, isort
-hypothesis==4.57.1        # via -r requirements/test.txt
+hypothesis==5.10.4        # via -r requirements/test.txt
 importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
-more-itertools==5.0.0     # via -r requirements/test.txt, pytest
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 packaging==20.3           # via -r requirements/test.txt, pytest
-pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest, pytest-django
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pep8==1.7.1               # via -r requirements/test.txt, pytest-pep8
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.8.1                 # via -r requirements/test.txt, pytest
 pycodestyle==2.5.0        # via -r requirements/test.txt
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==0.11.1     # via -r requirements/test.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==1.9.5             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
 pymongo==3.10.1           # via -r requirements/test.txt
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
@@ -45,15 +38,16 @@ pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/django-test.in
 pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
-pytest-pylint==0.14.1     # via -r requirements/test.txt
+pytest-pylint==0.15.1     # via -r requirements/test.txt
 pytest-xdist==1.31.0      # via -r requirements/test.txt
-pytest==4.6.9             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2019.3              # via -r requirements/django.txt, django
-scandir==1.10.0           # via -r requirements/test.txt, pathlib2
-singledispatch==3.4.0.3   # via -r requirements/test.txt, astroid, pylint
-six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, singledispatch, stevedore
+singledispatch==3.4.0.3   # via -r requirements/test.txt
+six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore
 sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
+sqlparse==0.3.1           # via -r requirements/django.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt
+typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
-wrapt==1.12.1             # via -r requirements/test.txt, astroid
+wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -8,7 +8,7 @@ apipkg==1.5               # via -r requirements/test.txt, execnet
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, hypothesis, pytest
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
-click==7.1.1              # via -r requirements/test.txt, click-log, edx-lint
+click==7.1.2              # via -r requirements/test.txt, click-log, edx-lint
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/test.txt
 edx-lint==1.4.1           # via -r requirements/test.txt
@@ -38,15 +38,16 @@ pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/django-test.in
 pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
-pytest-pylint==0.15.1     # via -r requirements/test.txt
+pytest-pylint==0.16.1     # via -r requirements/test.txt
 pytest-xdist==1.31.0      # via -r requirements/test.txt
-pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-pytz==2019.3              # via -r requirements/django.txt, django
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytz==2020.1              # via -r requirements/django.txt, django
 singledispatch==3.4.0.3   # via -r requirements/test.txt
 six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore
 sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
 sqlparse==0.3.1           # via -r requirements/django.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt
+toml==0.10.0              # via -r requirements/test.txt, pytest-pylint
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -42,8 +42,7 @@ pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements
 pytest-xdist==1.31.0      # via -r requirements/test.txt
 pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via -r requirements/django.txt, django
-singledispatch==3.4.0.3   # via -r requirements/test.txt
-six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore
+six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, stevedore
 sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
 sqlparse==0.3.1           # via -r requirements/django.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -38,7 +38,7 @@ pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/django-test.in
 pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
-pytest-pylint==0.16.0     # via -c requirements/constraints.txt, -r requirements/test.txt
+pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements/test.txt
 pytest-xdist==1.31.0      # via -r requirements/test.txt
 pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via -r requirements/django.txt, django
@@ -47,7 +47,6 @@ six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, moc
 sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
 sqlparse==0.3.1           # via -r requirements/django.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt
-toml==0.10.0              # via -r requirements/test.txt, pytest-pylint
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -38,9 +38,9 @@ pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/django-test.in
 pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
-pytest-pylint==0.16.1     # via -r requirements/test.txt
+pytest-pylint==0.16.0     # via -c requirements/constraints.txt, -r requirements/test.txt
 pytest-xdist==1.31.0      # via -r requirements/test.txt
-pytest==5.4.1             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-django, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via -r requirements/django.txt, django
 singledispatch==3.4.0.3   # via -r requirements/test.txt
 six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore

--- a/requirements/django.in
+++ b/requirements/django.in
@@ -5,4 +5,4 @@
 -c base.txt
 
 
-Django>=1.11
+Django>=2.2,<3.0

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 django==2.2.12            # via -r requirements/django.in
-pytz==2019.3              # via django
+pytz==2020.1              # via django
 sqlparse==0.3.1           # via django

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -4,5 +4,6 @@
 #
 #    make upgrade
 #
-django==1.11.29           # via -r requirements/django.in
+django==2.2.12            # via -r requirements/django.in
 pytz==2019.3              # via django
+sqlparse==0.3.1           # via django

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,28 +6,21 @@
 #
 alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via -r requirements/test.txt, execnet
-astroid==1.6.6            # via -r requirements/test.txt, pylint, pylint-celery
-atomicwrites==1.3.0       # via -r requirements/test.txt, pytest
+astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, hypothesis, pytest
 babel==2.8.0              # via sphinx
-backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, astroid, isort, pylint
 bleach==3.1.4             # via readme-renderer
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.1              # via -r requirements/test.txt, click-log, edx-lint
-configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/test.txt
 docutils==0.16            # via readme-renderer, sphinx
 edx-lint==1.4.1           # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-enum34==1.1.10            # via -r requirements/test.txt, astroid, hypothesis
 execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-xdist
-funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, isort
-hypothesis==4.57.1        # via -r requirements/test.txt
+hypothesis==5.10.4        # via -r requirements/test.txt
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
@@ -37,44 +30,48 @@ lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
-more-itertools==5.0.0     # via -r requirements/test.txt, pytest
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 packaging==20.3           # via -r requirements/test.txt, pytest, sphinx
-pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pep8==1.7.1               # via -r requirements/test.txt, pytest-pep8
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.8.1                 # via -r requirements/test.txt, pytest
 pycodestyle==2.5.0        # via -r requirements/test.txt
-pygments==2.5.2           # via readme-renderer, sphinx
+pygments==2.6.1           # via readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==0.11.1     # via -r requirements/test.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==1.9.5             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
 pymongo==3.10.1           # via -r requirements/test.txt
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
-pytest-pylint==0.14.1     # via -r requirements/test.txt
+pytest-pylint==0.15.1     # via -r requirements/test.txt
 pytest-xdist==1.31.0      # via -r requirements/test.txt
-pytest==4.6.9             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2019.3              # via babel
 readme-renderer==26.0     # via -r requirements/doc.in
 requests==2.23.0          # via sphinx
-scandir==1.10.0           # via -r requirements/test.txt, pathlib2
-singledispatch==3.4.0.3   # via -r requirements/test.txt, astroid, pylint
-six==1.14.0               # via -r requirements/test.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, readme-renderer, singledispatch, sphinx, stevedore
+singledispatch==3.4.0.3   # via -r requirements/test.txt
+six==1.14.0               # via -r requirements/test.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pytest-xdist, readme-renderer, singledispatch, stevedore
 snowballstemmer==2.0.0    # via sphinx
 sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
-sphinx==1.8.5             # via -r requirements/doc.in, edx-sphinx-theme
-sphinxcontrib-websupport==1.1.2  # via sphinx
+sphinx==3.0.2             # via -r requirements/doc.in, edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
+sphinxcontrib-jsmath==1.0.1  # via sphinx
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 stevedore==1.32.0         # via -r requirements/test.txt
-typing==3.7.4.1           # via sphinx
+typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 urllib3==1.25.9           # via requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
-wrapt==1.12.1             # via -r requirements/test.txt, astroid
+wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -13,7 +13,7 @@ bleach==3.1.4             # via readme-renderer
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
-click==7.1.1              # via -r requirements/test.txt, click-log, edx-lint
+click==7.1.2              # via -r requirements/test.txt, click-log, edx-lint
 coverage==5.1             # via -r requirements/test.txt, pytest-cov
 ddt==1.3.1                # via -r requirements/test.txt
 docutils==0.16            # via readme-renderer, sphinx
@@ -49,17 +49,17 @@ pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
-pytest-pylint==0.15.1     # via -r requirements/test.txt
+pytest-pylint==0.16.1     # via -r requirements/test.txt
 pytest-xdist==1.31.0      # via -r requirements/test.txt
-pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-pytz==2019.3              # via babel
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytz==2020.1              # via babel
 readme-renderer==26.0     # via -r requirements/doc.in
 requests==2.23.0          # via sphinx
 singledispatch==3.4.0.3   # via -r requirements/test.txt
 six==1.14.0               # via -r requirements/test.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pytest-xdist, readme-renderer, singledispatch, stevedore
 snowballstemmer==2.0.0    # via sphinx
 sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
-sphinx==3.0.2             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.0.3             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -67,6 +67,7 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 stevedore==1.32.0         # via -r requirements/test.txt
+toml==0.10.0              # via -r requirements/test.txt, pytest-pylint
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 urllib3==1.25.9           # via requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -55,8 +55,7 @@ pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements
 pytz==2020.1              # via babel
 readme-renderer==26.0     # via -r requirements/doc.in
 requests==2.23.0          # via sphinx
-singledispatch==3.4.0.3   # via -r requirements/test.txt
-six==1.14.0               # via -r requirements/test.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pytest-xdist, readme-renderer, singledispatch, stevedore
+six==1.14.0               # via -r requirements/test.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pytest-xdist, readme-renderer, stevedore
 snowballstemmer==2.0.0    # via sphinx
 sortedcontainers==2.1.0   # via -r requirements/test.txt, hypothesis
 sphinx==3.0.3             # via -r requirements/doc.in, edx-sphinx-theme

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -49,9 +49,9 @@ pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
-pytest-pylint==0.16.1     # via -r requirements/test.txt
+pytest-pylint==0.16.0     # via -c requirements/constraints.txt, -r requirements/test.txt
 pytest-xdist==1.31.0      # via -r requirements/test.txt
-pytest==5.4.1             # via -r requirements/test.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via babel
 readme-renderer==26.0     # via -r requirements/doc.in
 requests==2.23.0          # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -49,7 +49,7 @@ pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-forked==1.1.3      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
-pytest-pylint==0.16.0     # via -c requirements/constraints.txt, -r requirements/test.txt
+pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements/test.txt
 pytest-xdist==1.31.0      # via -r requirements/test.txt
 pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via babel
@@ -67,7 +67,6 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 stevedore==1.32.0         # via -r requirements/test.txt
-toml==0.10.0              # via -r requirements/test.txt, pytest-pylint
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 urllib3==1.25.9           # via requests
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
-click==7.1.1              # via pip-tools
-pip-tools==5.0.0          # via -r requirements/pip-tools.in
+click==7.1.2              # via pip-tools
+pip-tools==5.1.0          # via -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -14,4 +14,3 @@ pytest-cov
 pytest-pep8
 pytest-pylint
 pytest-xdist
-singledispatch

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -40,8 +40,7 @@ pytest-pep8==1.0.6        # via -r requirements/test.in
 pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements/test.in
 pytest-xdist==1.31.0      # via -r requirements/test.in
 pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-singledispatch==3.4.0.3   # via -r requirements/test.in
-six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore
+six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, stevedore
 sortedcontainers==2.1.0   # via hypothesis
 stevedore==1.32.0         # via -r requirements/base.txt
 typed-ast==1.4.1          # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -37,9 +37,9 @@ pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.in
-pytest-pylint==0.16.1     # via -r requirements/test.in
+pytest-pylint==0.16.0     # via -c requirements/constraints.txt, -r requirements/test.in
 pytest-xdist==1.31.0      # via -r requirements/test.in
-pytest==5.4.1             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 singledispatch==3.4.0.3   # via -r requirements/test.in
 six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore
 sortedcontainers==2.1.0   # via hypothesis

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,53 +5,46 @@
 #    make upgrade
 #
 apipkg==1.5               # via execnet
-astroid==1.6.6            # via pylint, pylint-celery
-atomicwrites==1.3.0       # via pytest
+astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via hypothesis, pytest
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
 click-log==0.3.2          # via edx-lint
 click==7.1.1              # via click-log, edx-lint
-configparser==4.0.2       # via importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via importlib-metadata, zipp
 coverage==5.1             # via -r requirements/test.in, pytest-cov
 ddt==1.3.1                # via -r requirements/test.in
 edx-lint==1.4.1           # via -r requirements/test.in
-enum34==1.1.10            # via astroid, hypothesis
 execnet==1.7.1            # via pytest-cache, pytest-xdist
-funcsigs==1.0.2           # via mock, pytest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, isort
-hypothesis==4.57.1        # via -r requirements/test.in
+hypothesis==5.10.4        # via -r requirements/test.in
 importlib-metadata==1.6.0  # via pluggy, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==5.0.0     # via pytest
+more-itertools==8.2.0     # via pytest
 packaging==20.3           # via pytest
-pathlib2==2.3.5           # via importlib-metadata, pytest
+pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via -r requirements/test.in
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.11.1     # via edx-lint
+pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
+pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils, pytest-pylint
 pymongo==3.10.1           # via -r requirements/base.txt
 pyparsing==2.4.7          # via packaging
 pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.in
-pytest-pylint==0.14.1     # via -r requirements/test.in
+pytest-pylint==0.15.1     # via -r requirements/test.in
 pytest-xdist==1.31.0      # via -r requirements/test.in
-pytest==4.6.9             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
-scandir==1.10.0           # via pathlib2
-singledispatch==3.4.0.3   # via -r requirements/test.in, astroid, pylint
-six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, more-itertools, packaging, pathlib2, pylint, pytest, pytest-pylint, pytest-xdist, singledispatch, stevedore
+pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+singledispatch==3.4.0.3   # via -r requirements/test.in
+six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore
 sortedcontainers==2.1.0   # via hypothesis
 stevedore==1.32.0         # via -r requirements/base.txt
+typed-ast==1.4.1          # via astroid
 wcwidth==0.1.9            # via pytest
-wrapt==1.12.1             # via astroid
+wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ apipkg==1.5               # via execnet
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via hypothesis, pytest
 click-log==0.3.2          # via edx-lint
-click==7.1.1              # via click-log, edx-lint
+click==7.1.2              # via click-log, edx-lint
 coverage==5.1             # via -r requirements/test.in, pytest-cov
 ddt==1.3.1                # via -r requirements/test.in
 edx-lint==1.4.1           # via -r requirements/test.in
@@ -37,13 +37,14 @@ pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.in
-pytest-pylint==0.15.1     # via -r requirements/test.in
+pytest-pylint==0.16.1     # via -r requirements/test.in
 pytest-xdist==1.31.0      # via -r requirements/test.in
-pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
+pytest==5.4.1             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 singledispatch==3.4.0.3   # via -r requirements/test.in
 six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore
 sortedcontainers==2.1.0   # via hypothesis
 stevedore==1.32.0         # via -r requirements/base.txt
+toml==0.10.0              # via pytest-pylint
 typed-ast==1.4.1          # via astroid
 wcwidth==0.1.9            # via pytest
 wrapt==1.11.2             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -37,14 +37,13 @@ pytest-cache==1.0         # via pytest-pep8
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.in
-pytest-pylint==0.16.0     # via -c requirements/constraints.txt, -r requirements/test.in
+pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements/test.in
 pytest-xdist==1.31.0      # via -r requirements/test.in
 pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 singledispatch==3.4.0.3   # via -r requirements/test.in
 six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, singledispatch, stevedore
 sortedcontainers==2.1.0   # via hypothesis
 stevedore==1.32.0         # via -r requirements/base.txt
-toml==0.10.0              # via pytest-pylint
 typed-ast==1.4.1          # via astroid
 wcwidth==0.1.9            # via pytest
 wrapt==1.11.2             # via astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -14,7 +14,7 @@ docopt==0.6.2             # via coveralls
 filelock==3.0.12          # via tox, virtualenv
 idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.4.0  # via virtualenv
+importlib-resources==1.5.0  # via virtualenv
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,37 +5,25 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-certifi==2020.4.5.1       # via requests, urllib3
-cffi==1.14.0              # via cryptography
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
 coverage==5.1             # via coveralls
-coveralls==1.11.1         # via -r requirements/travis.in
-cryptography==2.9.2       # via pyopenssl, urllib3
+coveralls==2.0.0          # via -r requirements/travis.in
 distlib==0.3.0            # via virtualenv
 docopt==0.6.2             # via coveralls
-enum34==1.1.10            # via cryptography
 filelock==3.0.12          # via tox, virtualenv
-idna==2.9                 # via requests, urllib3
+idna==2.9                 # via requests
 importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
 importlib-resources==1.4.0  # via virtualenv
-ipaddress==1.0.23         # via cryptography, urllib3
 packaging==20.3           # via tox
-pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pycparser==2.20           # via cffi
-pyopenssl==19.1.0         # via urllib3
 pyparsing==2.4.7          # via packaging
 requests==2.23.0          # via coveralls
-scandir==1.10.0           # via pathlib2
-singledispatch==3.4.0.3   # via importlib-resources
-six==1.14.0               # via cryptography, packaging, pathlib2, pyopenssl, singledispatch, tox, virtualenv
+six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/travis.in
 tox==3.14.6               # via -r requirements/travis.in, tox-battery
-typing==3.7.4.1           # via importlib-resources
-urllib3[secure]==1.25.9   # via coveralls, requests
+urllib3==1.25.9           # via requests
 virtualenv==20.0.18       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def is_requirement(line):
 
 setup(
     name='edx-opaque-keys',
-    version='2.0.2',
+    version='2.1.0',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[
@@ -45,6 +45,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
     ],
     # We are including the tests because other libraries do use mixins from them.
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
-envlist = py{27,35}-django{111},py35-django{20,21,22},quality,without-django
+envlist = {py35,py38}-django{22,30},quality,without-django
 skip_missing_interpreters = True
 
 # Run most tests with the django functionality included
 [testenv]
 deps =
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     -r{toxinidir}/requirements/django-test.txt
 commands = pytest --disable-pytest-warnings --nomigrations {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py38}-django{22,30},quality,without-django
+envlist = py35-django22, py38-django{22,30},quality,without-django
 skip_missing_interpreters = True
 
 # Run most tests with the django functionality included


### PR DESCRIPTION
Relevant JIRA : [https://openedx.atlassian.net/browse/BOM-1538](https://openedx.atlassian.net/browse/BOM-1538)
- Removed Python 2.7 
- Added Python 3.8 to testing
- Removed Django versions < 2.2
- Ran make upgrade
- Fixed some quality failures