### PR TITLE
Fixed django 3.0 warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 # 2.0.2
 
+* Fixed django warnings
+
+# 2.0.2
+
 * setup.py now properly uses requirements files
 
 # 2.0.1

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -51,7 +51,7 @@ class CreatorMixin:
         super(CreatorMixin, self).contribute_to_class(cls, name, *args, **kwargs)
         setattr(cls, name, _Creator(self))
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection):
         return self.to_python(value)
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def is_requirement(line):
 
 setup(
     name='edx-opaque-keys',
-    version='2.1.0',
+    version='2.1.1',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[


### PR DESCRIPTION
JIRA: [BOM-1879](https://openedx.atlassian.net/browse/BOM-1879)

`Support for the context argument of Field.from_db_value() and Expression.convert_value() is removed.`
https://docs.djangoproject.com/en/3.0/releases/3.0/#features-removed-in-3-0