### PR TITLE
Pin importlib-metadata to 1.7.0 for python35

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,3 +20,6 @@ pytest-pylint<0.16
 
 # pytest-xdist>=2.0.0 removes some aliases and until pytest-django>=3.10.0 is released, this will break tests.
 pytest-xdist==1.34.0
+
+# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python35
+importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/doc.txt, pylint, pylint-celery
 attrs==20.2.0             # via -r requirements/doc.txt, hypothesis, pytest
 babel==2.8.0              # via -r requirements/doc.txt, sphinx
-bleach==3.2.0             # via -r requirements/doc.txt, readme-renderer
+bleach==3.2.1             # via -r requirements/doc.txt, readme-renderer
 certifi==2020.6.20        # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/doc.txt, edx-lint
@@ -28,7 +28,7 @@ filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 hypothesis==5.33.2        # via -r requirements/doc.txt
 idna==2.10                # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
-importlib-metadata==1.7.0  # via -r requirements/doc.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 isort==4.3.21             # via -r requirements/doc.txt, pylint
 jinja2==2.11.2            # via -r requirements/doc.txt, sphinx
@@ -45,7 +45,7 @@ pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, tox
 py==1.9.0                 # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, pytest-forked, tox
 pycodestyle==2.6.0        # via -r requirements/doc.txt
-pygments==2.7.0           # via -r requirements/doc.txt, readme-renderer, sphinx
+pygments==2.7.1           # via -r requirements/doc.txt, readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/doc.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/doc.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/doc.txt, pylint-celery, pylint-django

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -14,7 +14,7 @@ ddt==1.4.1                # via -r requirements/test.txt
 edx-lint==1.5.2           # via -r requirements/test.txt
 execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-xdist
 hypothesis==5.33.2        # via -r requirements/test.txt
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 mccabe==0.6.1             # via -r requirements/test.txt, pylint

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -9,7 +9,7 @@ apipkg==1.5               # via -r requirements/test.txt, execnet
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.2.0             # via -r requirements/test.txt, hypothesis, pytest
 babel==2.8.0              # via sphinx
-bleach==3.2.0             # via readme-renderer
+bleach==3.2.1             # via readme-renderer
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
@@ -23,7 +23,7 @@ execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-x
 hypothesis==5.33.2        # via -r requirements/test.txt
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 jinja2==2.11.2            # via sphinx
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
@@ -38,7 +38,7 @@ pep8==1.7.1               # via -r requirements/test.txt, pytest-pep8
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest, pytest-forked
 pycodestyle==2.6.0        # via -r requirements/test.txt
-pygments==2.7.0           # via readme-renderer, sphinx
+pygments==2.7.1           # via readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ ddt==1.4.1                # via -r requirements/test.in
 edx-lint==1.5.2           # via -r requirements/test.in
 execnet==1.7.1            # via pytest-cache, pytest-xdist
 hypothesis==5.33.2        # via -r requirements/test.in
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -13,7 +13,7 @@ distlib==0.3.1            # via virtualenv
 docopt==0.6.2             # via coveralls
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox


### PR DESCRIPTION
- Pinned `importlib-metadata==1.7.0` as `version>1.7.0` is causing conflicts for python35 in running `make upgrade`.
