### PR TITLE
Unpin importlib-metadata constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,6 +20,3 @@ pytest-pylint<0.16
 
 # pytest-xdist>=2.0.0 removes some aliases and until pytest-django>=3.10.0 is released, this will break tests.
 pytest-xdist==1.34.0
-
-# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python35
-importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 hypothesis==5.33.2        # via -r requirements/doc.txt
 idna==2.10                # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/doc.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/doc.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 isort==4.3.21             # via -r requirements/doc.txt, pylint
 jinja2==2.11.2            # via -r requirements/doc.txt, sphinx
@@ -60,7 +60,7 @@ pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements
 pytest-xdist==1.34.0      # via -c requirements/constraints.txt, -r requirements/doc.txt
 pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via -r requirements/doc.txt, babel
-readme-renderer==26.0     # via -r requirements/doc.txt
+readme-renderer==27.0     # via -r requirements/doc.txt
 requests==2.24.0          # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, sphinx
 six==1.15.0               # via -r requirements/doc.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pip-tools, pytest-xdist, readme-renderer, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/doc.txt, sphinx
@@ -75,7 +75,7 @@ sphinxcontrib-serializinghtml==1.1.4  # via -r requirements/doc.txt, sphinx
 stevedore==1.32.0         # via -r requirements/doc.txt
 toml==0.10.1              # via -r requirements/travis.txt, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.20.0               # via -r requirements/travis.txt, tox-battery
+tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/doc.txt, astroid
 urllib3==1.25.10          # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 virtualenv==20.0.33       # via -r requirements/travis.txt, tox

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -14,7 +14,7 @@ ddt==1.4.1                # via -r requirements/test.txt
 edx-lint==1.5.2           # via -r requirements/test.txt
 execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-xdist
 hypothesis==5.33.2        # via -r requirements/test.txt
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
@@ -44,7 +44,7 @@ pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements
 pytz==2020.1              # via -r requirements/django.txt, django
 six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, mock, packaging, pathlib2, pytest-xdist, stevedore
 sortedcontainers==2.2.2   # via -r requirements/test.txt, hypothesis
-sqlparse==0.4.0           # via -r requirements/django.txt, django
+sqlparse==0.4.1           # via -r requirements/django.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -6,4 +6,4 @@
 #
 django==2.2.16            # via -r requirements/django.in
 pytz==2020.1              # via django
-sqlparse==0.4.0           # via django
+sqlparse==0.4.1           # via django

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -23,7 +23,7 @@ execnet==1.7.1            # via -r requirements/test.txt, pytest-cache, pytest-x
 hypothesis==5.33.2        # via -r requirements/test.txt
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 jinja2==2.11.2            # via sphinx
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
@@ -53,7 +53,7 @@ pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements
 pytest-xdist==1.34.0      # via -c requirements/constraints.txt, -r requirements/test.txt
 pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via babel
-readme-renderer==26.0     # via -r requirements/doc.in
+readme-renderer==27.0     # via -r requirements/doc.in
 requests==2.24.0          # via sphinx
 six==1.15.0               # via -r requirements/test.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pytest-xdist, readme-renderer, stevedore
 snowballstemmer==2.0.0    # via sphinx

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ ddt==1.4.1                # via -r requirements/test.in
 edx-lint==1.5.2           # via -r requirements/test.in
 execnet==1.7.1            # via pytest-cache, pytest-xdist
 hypothesis==5.33.2        # via -r requirements/test.in
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -13,7 +13,7 @@ distlib==0.3.1            # via virtualenv
 docopt==0.6.2             # via coveralls
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -23,7 +23,7 @@ requests==2.24.0          # via coveralls
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.20.0               # via -r requirements/travis.in, tox-battery
+tox==3.20.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.10          # via requests
 virtualenv==20.0.33       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
- `importlib-metadata<2.0.0` was causing conflicts in running `make upgrade` with `python3.5`.
- Unpinned `importlib-metadata` constraint after fixing the issue in https://github.com/pypa/virtualenv/pull/1953 and https://github.com/tox-dev/tox/pull/1682.