### PR TITLE
Pinned pytest-django<4.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-pbr==5.5.0                # via stevedore
+pbr==5.5.1                # via stevedore
 pymongo==3.11.0           # via -r requirements/base.in
 six==1.15.0               # via -r requirements/base.in, stevedore
 stevedore==1.32.0         # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,6 +17,8 @@ pytest<=5.3
 # version >= 0.16 requires pytest >= 5.4
 pytest-pylint<0.16
 
-
 # pytest-xdist>=2.0.0 removes some aliases and until pytest-django>=3.10.0 is released, this will break tests.
 pytest-xdist==1.34.0
+
+# version 4.0.0 requires pytest >= 5.4.0
+pytest-django<4.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,7 +29,7 @@ hypothesis==5.33.2        # via -r requirements/doc.txt
 idna==2.10                # via -r requirements/doc.txt, -r requirements/travis.txt, requests
 imagesize==1.2.0          # via -r requirements/doc.txt, sphinx
 importlib-metadata==2.0.0  # via -r requirements/doc.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
+importlib-resources==3.2.1  # via -r requirements/travis.txt, virtualenv
 isort==4.3.21             # via -r requirements/doc.txt, pylint
 jinja2==2.11.2            # via -r requirements/doc.txt, sphinx
 lazy-object-proxy==1.4.3  # via -r requirements/doc.txt, astroid
@@ -39,13 +39,13 @@ mock==3.0.5               # via -r requirements/doc.txt
 more-itertools==8.5.0     # via -r requirements/doc.txt, pytest
 packaging==20.4           # via -r requirements/doc.txt, -r requirements/travis.txt, bleach, pytest, sphinx, tox
 pathlib2==2.3.5           # via -r requirements/doc.txt, pytest
-pbr==5.5.0                # via -r requirements/doc.txt, stevedore
+pbr==5.5.1                # via -r requirements/doc.txt, stevedore
 pep8==1.7.1               # via -r requirements/doc.txt, pytest-pep8
 pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, tox
 py==1.9.0                 # via -r requirements/doc.txt, -r requirements/travis.txt, pytest, pytest-forked, tox
 pycodestyle==2.6.0        # via -r requirements/doc.txt
-pygments==2.7.1           # via -r requirements/doc.txt, readme-renderer, sphinx
+pygments==2.7.2           # via -r requirements/doc.txt, readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/doc.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/doc.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/doc.txt, pylint-celery, pylint-django
@@ -60,7 +60,7 @@ pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements
 pytest-xdist==1.34.0      # via -c requirements/constraints.txt, -r requirements/doc.txt
 pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/doc.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via -r requirements/doc.txt, babel
-readme-renderer==27.0     # via -r requirements/doc.txt
+readme-renderer==28.0     # via -r requirements/doc.txt
 requests==2.24.0          # via -r requirements/doc.txt, -r requirements/travis.txt, coveralls, sphinx
 six==1.15.0               # via -r requirements/doc.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pip-tools, pytest-xdist, readme-renderer, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/doc.txt, sphinx
@@ -77,8 +77,8 @@ toml==0.10.1              # via -r requirements/travis.txt, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
 tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/doc.txt, astroid
-urllib3==1.25.10          # via -r requirements/doc.txt, -r requirements/travis.txt, requests
-virtualenv==20.0.34       # via -r requirements/travis.txt, tox
+urllib3==1.25.11          # via -r requirements/doc.txt, -r requirements/travis.txt, requests
+virtualenv==20.1.0        # via -r requirements/travis.txt, tox
 wcwidth==0.2.5            # via -r requirements/doc.txt, pytest
 webencodings==0.5.1       # via -r requirements/doc.txt, bleach
 wrapt==1.11.2             # via -r requirements/doc.txt, astroid

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -22,7 +22,7 @@ mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 packaging==20.4           # via -r requirements/test.txt, pytest
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
-pbr==5.5.0                # via -r requirements/test.txt, stevedore
+pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pep8==1.7.1               # via -r requirements/test.txt, pytest-pep8
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest, pytest-forked
@@ -35,7 +35,7 @@ pymongo==3.11.0           # via -r requirements/test.txt
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cache==1.0         # via -r requirements/test.txt, pytest-pep8
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==3.10.0     # via -r requirements/django-test.in
+pytest-django==3.10.0     # via -c requirements/constraints.txt, -r requirements/django-test.in
 pytest-forked==1.3.0      # via -r requirements/test.txt, pytest-xdist
 pytest-pep8==1.0.6        # via -r requirements/test.txt
 pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -33,12 +33,12 @@ mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
-pbr==5.5.0                # via -r requirements/test.txt, stevedore
+pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pep8==1.7.1               # via -r requirements/test.txt, pytest-pep8
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest, pytest-forked
 pycodestyle==2.6.0        # via -r requirements/test.txt
-pygments==2.7.1           # via readme-renderer, sphinx
+pygments==2.7.2           # via readme-renderer, sphinx
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
@@ -53,7 +53,7 @@ pytest-pylint==0.15.1     # via -c requirements/constraints.txt, -r requirements
 pytest-xdist==1.34.0      # via -c requirements/constraints.txt, -r requirements/test.txt
 pytest==5.3.0             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cache, pytest-cov, pytest-forked, pytest-pep8, pytest-pylint, pytest-xdist
 pytz==2020.1              # via babel
-readme-renderer==27.0     # via -r requirements/doc.in
+readme-renderer==28.0     # via -r requirements/doc.in
 requests==2.24.0          # via sphinx
 six==1.15.0               # via -r requirements/test.txt, astroid, bleach, edx-lint, edx-sphinx-theme, mock, packaging, pathlib2, pytest-xdist, readme-renderer, stevedore
 snowballstemmer==2.0.0    # via sphinx
@@ -67,7 +67,7 @@ sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 stevedore==1.32.0         # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
-urllib3==1.25.10          # via requests
+urllib3==1.25.11          # via requests
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,7 +22,7 @@ mock==3.0.5               # via -r requirements/test.in
 more-itertools==8.5.0     # via pytest
 packaging==20.4           # via pytest
 pathlib2==2.3.5           # via pytest
-pbr==5.5.0                # via -r requirements/base.txt, stevedore
+pbr==5.5.1                # via -r requirements/base.txt, stevedore
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest, pytest-forked

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -14,7 +14,7 @@ docopt==0.6.2             # via coveralls
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
 importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
+importlib-resources==3.2.1  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
@@ -24,6 +24,6 @@ six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.20.1               # via -r requirements/travis.in, tox-battery
-urllib3==1.25.10          # via requests
-virtualenv==20.0.34       # via tox
+urllib3==1.25.11          # via requests
+virtualenv==20.1.0        # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
`pytest-django=4.0.0` requires `pytest>=5.4` which is currently pinned to `pytest<5.3` hence causing the build failure in `python requirements upgrade`: https://build.testeng.edx.org/job/opaque-keys-upgrade-python-requirements/74/console
So pinning the version untill `pytest<5.3` constraint is removed.