### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ clear and consistent API. See the code's docstrings for more information.
 
 See the `edx-platform wiki documentation`_ for more detail.
 
-.. |build-status| image:: https://travis-ci.org/edx/opaque-keys.svg?branch=master
-   :target: https://travis-ci.org/edx/opaque-keys
+.. |build-status| image:: https://travis-ci.com/edx/opaque-keys.svg?branch=master
+   :target: https://travis-ci.com/edx/opaque-keys
 .. |coverage-status| image:: https://coveralls.io/repos/edx/opaque-keys/badge.svg?branch=master
    :target: https://coveralls.io/r/edx/opaque-keys
 .. _`edx-platform wiki documentation`: https://github.com/edx/edx-platform/wiki/Opaque-Keys-(Locators)


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089