### PR TITLE
Remove constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
     secure: cnCf0zDyTEJycCDcxhH1GsvOWNGImjwc8WIrD/D5Hsk7p0IeMaEjc/t6gc1LO2iQKGlZq/BLDxUBmsEbrQUD1wvSBg/J+9Ji6yn9jJ87X6QSNq+Xy0brLe9RAeMElG3OLqbj6FHRMzk2EmOEJXI9ATqlXfdqFwgKCYrvf2GT2Ug=
   on:
     tags: true
-    python: '3.5'
+    python: '3.8'
     condition: $TOXENV = django22
     distributions: sdist bdist_wheel
     repo: edx/opaque-keys

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+# 2.2.0
+
+* Dropped support for Python3.5
+* Added support for Django 3.0 & Django 3.1
+
 # 2.0.2
 
 * Fixed django warnings

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -8,14 +8,6 @@ formats, and allowing new serialization formats to be installed transparently.
 """
 from abc import ABCMeta, abstractmethod
 from functools import total_ordering
-from six import (
-    iteritems,
-    python_2_unicode_compatible,
-    text_type,
-    viewkeys,
-    viewitems,
-    with_metaclass,
-)
 from stevedore.enabled import EnabledExtensionManager
 
 # pylint: disable=wrong-import-order

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -101,7 +101,7 @@ class OpaqueKeyField(CreatorMixin, CharField):
         if value is self.Empty or value is None:
             return None
 
-        error_message = "%s is not an instance of six.string_types or %s" % (value, self.KEY_CLASS)
+        error_message = "%s is not an instance of str or %s" % (value, self.KEY_CLASS)
         assert isinstance(value, (str,) + (self.KEY_CLASS,)), error_message
         if value == '':
             # handle empty string for models being created w/o fields populated

--- a/opaque_keys/edx/tests/test_course_locators.py
+++ b/opaque_keys/edx/tests/test_course_locators.py
@@ -122,7 +122,7 @@ class TestCourseKeys(LocatorBaseTest, TestDeprecated):
         'mit.eecs+' + CourseLocator.BRANCH_PREFIX + '@this+' + CourseLocator.BRANCH_PREFIX + '@that',
         'mit.eecs+' + CourseLocator.BRANCH_PREFIX + '@this+' + CourseLocator.BRANCH_PREFIX,
         'mit.eecs+' + CourseLocator.BRANCH_PREFIX + '@this ',
-        'mit.eecs+' + CourseLocator.BRANCH_PREFIX + '@th%is ',  # pylint: disable=unicode-format-string
+        'mit.eecs+' + CourseLocator.BRANCH_PREFIX + '@th%is ',
         '\ufffd',
     )
     def test_course_constructor_bad_package_id(self, bad_id):

--- a/opaque_keys/tests/test_opaque_keys.py
+++ b/opaque_keys/tests/test_opaque_keys.py
@@ -118,11 +118,11 @@ class KeyTests(TestCase):
         self.assertEqual(base_key._to_string(), '15')  # pylint: disable=protected-access
         self.assertEqual(len(base_key), len('base10:15'))
 
-        dict_key = DummyKey.from_string('dict:{"foo": "bar"}')  # pylint: disable=unicode-format-string
+        dict_key = DummyKey.from_string('dict:{"foo": "bar"}')
         self.assertIsInstance(dict_key, DictKey)
         self.assertEqual(dict_key.value, {"foo": "bar"})
         self.assertEqual(dict_key._to_string(), '{"foo": "bar"}')  # pylint: disable=protected-access
-        self.assertEqual(len(dict_key), len('dict:{"foo": "bar"}'))  # pylint: disable=unicode-format-string
+        self.assertEqual(len(dict_key), len('dict:{"foo": "bar"}'))
 
     def test_bad_keys(self):
         with self.assertRaises(InvalidKeyError):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,5 +2,4 @@
 -c constraints.txt
 
 pymongo>=2.7.2
-six>=1.10.0
 stevedore>=0.14.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,5 @@ pbr==5.5.1
     # via stevedore
 pymongo==3.11.2
     # via -r requirements/base.in
-six==1.15.0
-    # via -r requirements/base.in
 stevedore==3.3.0
     # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,17 +8,5 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-
-
-# pytest command fails if pytest > 5.3 is used
-# Look into https://github.com/pytest-dev/pytest/issues/6925
-pytest<=5.3
-
-# version >= 0.16 requires pytest >= 5.4
-pytest-pylint<0.16
-
-# pytest-xdist>=2.0.0 removes some aliases and until pytest-django>=3.10.0 is released, this will break tests.
-pytest-xdist==1.34.0
-
-# version 4.0.0 requires pytest >= 5.4.0
-pytest-django<4.0.0
+# stay on LTS release
+Django<2.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,8 @@
 
 # stay on LTS release
 Django<2.3
+
+# pytest>=5.6.0 fails to fetch the tests and hence all the tests fail
+pytest<5.6.0
+
+pytest-xdist<2.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -114,10 +114,6 @@ imagesize==1.2.0
     # via
     #   -r requirements/doc.txt
     #   sphinx
-iniconfig==1.1.1
-    # via
-    #   -r requirements/doc.txt
-    #   pytest
 isort==5.7.0
     # via
     #   -r requirements/doc.txt
@@ -141,6 +137,10 @@ mccabe==0.6.1
     #   pylint
 mock==4.0.3
     # via -r requirements/doc.txt
+more-itertools==8.6.0
+    # via
+    #   -r requirements/doc.txt
+    #   pytest
 packaging==20.8
     # via
     #   -r requirements/doc.txt
@@ -221,10 +221,13 @@ pytest-pep8==1.0.6
     # via -r requirements/doc.txt
 pytest-pylint==0.18.0
     # via -r requirements/doc.txt
-pytest-xdist==2.2.0
-    # via -r requirements/doc.txt
-pytest==6.2.2
+pytest-xdist==1.34.0
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.txt
+pytest==5.4.3
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/doc.txt
     #   pytest-cache
     #   pytest-cov
@@ -261,6 +264,7 @@ six==1.15.0
     #   bleach
     #   edx-lint
     #   edx-sphinx-theme
+    #   pytest-xdist
     #   readme-renderer
     #   tox
     #   virtualenv
@@ -317,7 +321,6 @@ toml==0.10.2
     #   -r requirements/doc.txt
     #   -r requirements/travis.txt
     #   pylint
-    #   pytest
     #   pytest-pylint
     #   tox
 tox-battery==0.6.1
@@ -335,6 +338,10 @@ virtualenv==20.4.0
     # via
     #   -r requirements/travis.txt
     #   tox
+wcwidth==0.2.5
+    # via
+    #   -r requirements/doc.txt
+    #   pytest
 webencodings==0.5.1
     # via
     #   -r requirements/doc.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,7 +30,7 @@ babel==2.9.0
     # via
     #   -r requirements/doc.txt
     #   sphinx
-bleach==3.2.2
+bleach==3.2.3
     # via
     #   -r requirements/doc.txt
     #   readme-renderer
@@ -53,9 +53,14 @@ click==7.1.2
     #   -r requirements/doc.txt
     #   -r requirements/pip-tools.txt
     #   click-log
+    #   code-annotations
     #   edx-lint
     #   pip-tools
-coverage==5.3.1
+code-annotations==1.0.2
+    # via
+    #   -r requirements/doc.txt
+    #   edx-lint
+coverage==5.4
     # via
     #   -r requirements/doc.txt
     #   -r requirements/travis.txt
@@ -69,6 +74,12 @@ distlib==0.3.1
     # via
     #   -r requirements/travis.txt
     #   virtualenv
+django==2.2.17
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.txt
+    #   code-annotations
+    #   edx-lint
 docopt==0.6.2
     # via
     #   -r requirements/travis.txt
@@ -78,11 +89,11 @@ docutils==0.16
     #   -r requirements/doc.txt
     #   readme-renderer
     #   sphinx
-edx-lint==1.6
+edx-lint==3.0.2
     # via -r requirements/doc.txt
 edx-sphinx-theme==1.6.1
     # via -r requirements/doc.txt
-execnet==1.7.1
+execnet==1.8.0
     # via
     #   -r requirements/doc.txt
     #   pytest-cache
@@ -92,7 +103,7 @@ filelock==3.0.12
     #   -r requirements/travis.txt
     #   tox
     #   virtualenv
-hypothesis==6.0.2
+hypothesis==6.0.4
     # via -r requirements/doc.txt
 idna==2.10
     # via
@@ -103,6 +114,10 @@ imagesize==1.2.0
     # via
     #   -r requirements/doc.txt
     #   sphinx
+iniconfig==1.1.1
+    # via
+    #   -r requirements/doc.txt
+    #   pytest
 isort==5.7.0
     # via
     #   -r requirements/doc.txt
@@ -110,6 +125,7 @@ isort==5.7.0
 jinja2==2.11.2
     # via
     #   -r requirements/doc.txt
+    #   code-annotations
     #   sphinx
 lazy-object-proxy==1.4.3
     # via
@@ -125,10 +141,6 @@ mccabe==0.6.1
     #   pylint
 mock==4.0.3
     # via -r requirements/doc.txt
-more-itertools==8.6.0
-    # via
-    #   -r requirements/doc.txt
-    #   pytest
 packaging==20.8
     # via
     #   -r requirements/doc.txt
@@ -171,7 +183,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/doc.txt
     #   edx-lint
-pylint-django==2.3.0
+pylint-django==2.4.2
     # via
     #   -r requirements/doc.txt
     #   edx-lint
@@ -207,17 +219,12 @@ pytest-forked==1.3.0
     #   pytest-xdist
 pytest-pep8==1.0.6
     # via -r requirements/doc.txt
-pytest-pylint==0.15.1
+pytest-pylint==0.18.0
+    # via -r requirements/doc.txt
+pytest-xdist==2.2.0
+    # via -r requirements/doc.txt
+pytest==6.2.2
     # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/doc.txt
-pytest-xdist==1.34.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/doc.txt
-pytest==5.3.0
-    # via
-    #   -c requirements/constraints.txt
     #   -r requirements/doc.txt
     #   pytest-cache
     #   pytest-cov
@@ -225,10 +232,19 @@ pytest==5.3.0
     #   pytest-pep8
     #   pytest-pylint
     #   pytest-xdist
+python-slugify==4.0.1
+    # via
+    #   -r requirements/doc.txt
+    #   code-annotations
 pytz==2020.5
     # via
     #   -r requirements/doc.txt
     #   babel
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/doc.txt
+    #   code-annotations
 readme-renderer==28.0
     # via -r requirements/doc.txt
 requests==2.25.1
@@ -245,11 +261,10 @@ six==1.15.0
     #   bleach
     #   edx-lint
     #   edx-sphinx-theme
-    #   pytest-xdist
     #   readme-renderer
     #   tox
     #   virtualenv
-snowballstemmer==2.0.0
+snowballstemmer==2.1.0
     # via
     #   -r requirements/doc.txt
     #   sphinx
@@ -285,21 +300,33 @@ sphinxcontrib-serializinghtml==1.1.4
     # via
     #   -r requirements/doc.txt
     #   sphinx
+sqlparse==0.4.1
+    # via
+    #   -r requirements/doc.txt
+    #   django
 stevedore==3.3.0
-    # via -r requirements/doc.txt
+    # via
+    #   -r requirements/doc.txt
+    #   code-annotations
+text-unidecode==1.3
+    # via
+    #   -r requirements/doc.txt
+    #   python-slugify
 toml==0.10.2
     # via
     #   -r requirements/doc.txt
     #   -r requirements/travis.txt
     #   pylint
+    #   pytest
+    #   pytest-pylint
     #   tox
 tox-battery==0.6.1
     # via -r requirements/travis.txt
-tox==3.21.2
+tox==3.21.3
     # via
     #   -r requirements/travis.txt
     #   tox-battery
-urllib3==1.26.2
+urllib3==1.26.3
     # via
     #   -r requirements/doc.txt
     #   -r requirements/travis.txt
@@ -308,10 +335,6 @@ virtualenv==20.4.0
     # via
     #   -r requirements/travis.txt
     #   tox
-wcwidth==0.2.5
-    # via
-    #   -r requirements/doc.txt
-    #   pytest
 webencodings==0.5.1
     # via
     #   -r requirements/doc.txt

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -26,41 +26,59 @@ click==7.1.2
     # via
     #   -r requirements/test.txt
     #   click-log
+    #   code-annotations
     #   edx-lint
-coverage==5.3.1
+code-annotations==1.0.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+coverage==5.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 ddt==1.4.1
     # via -r requirements/test.txt
-    # via -r requirements/django.txt
-edx-lint==1.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/django.txt
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   edx-lint
+edx-lint==3.0.2
     # via -r requirements/test.txt
-execnet==1.7.1
+execnet==1.8.0
     # via
     #   -r requirements/test.txt
     #   pytest-cache
     #   pytest-xdist
-hypothesis==6.0.2
+hypothesis==6.0.4
     # via -r requirements/test.txt
+iniconfig==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 isort==5.7.0
     # via
     #   -r requirements/test.txt
     #   pylint
+jinja2==2.11.2
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
 lazy-object-proxy==1.4.3
     # via
     #   -r requirements/test.txt
     #   astroid
+markupsafe==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   jinja2
 mccabe==0.6.1
     # via
     #   -r requirements/test.txt
     #   pylint
 mock==4.0.3
     # via -r requirements/test.txt
-more-itertools==8.6.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 packaging==20.8
     # via
     #   -r requirements/test.txt
@@ -88,7 +106,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-django==2.3.0
+pylint-django==2.4.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -117,27 +135,20 @@ pytest-cache==1.0
     #   pytest-pep8
 pytest-cov==2.11.1
     # via -r requirements/test.txt
-pytest-django==3.10.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/django-test.in
+pytest-django==4.1.0
+    # via -r requirements/django-test.in
 pytest-forked==1.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-xdist
 pytest-pep8==1.0.6
     # via -r requirements/test.txt
-pytest-pylint==0.15.1
+pytest-pylint==0.18.0
+    # via -r requirements/test.txt
+pytest-xdist==2.2.0
+    # via -r requirements/test.txt
+pytest==6.2.2
     # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-pytest-xdist==1.34.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-pytest==5.3.0
-    # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pytest-cache
     #   pytest-cov
@@ -146,16 +157,24 @@ pytest==5.3.0
     #   pytest-pep8
     #   pytest-pylint
     #   pytest-xdist
+python-slugify==4.0.1
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
 pytz==2020.5
     # via
     #   -r requirements/django.txt
+    #   -r requirements/test.txt
     #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
 six==1.15.0
     # via
     #   -r requirements/test.txt
     #   astroid
     #   edx-lint
-    #   pytest-xdist
 sortedcontainers==2.3.0
     # via
     #   -r requirements/test.txt
@@ -163,17 +182,22 @@ sortedcontainers==2.3.0
 sqlparse==0.4.1
     # via
     #   -r requirements/django.txt
+    #   -r requirements/test.txt
     #   django
 stevedore==3.3.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
+text-unidecode==1.3
+    # via
+    #   -r requirements/test.txt
+    #   python-slugify
 toml==0.10.2
     # via
     #   -r requirements/test.txt
     #   pylint
-wcwidth==0.2.5
-    # via
-    #   -r requirements/test.txt
     #   pytest
+    #   pytest-pylint
 wrapt==1.12.1
     # via
     #   -r requirements/test.txt

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -53,10 +53,6 @@ execnet==1.8.0
     #   pytest-xdist
 hypothesis==6.0.4
     # via -r requirements/test.txt
-iniconfig==1.1.1
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 isort==5.7.0
     # via
     #   -r requirements/test.txt
@@ -79,6 +75,10 @@ mccabe==0.6.1
     #   pylint
 mock==4.0.3
     # via -r requirements/test.txt
+more-itertools==8.6.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 packaging==20.8
     # via
     #   -r requirements/test.txt
@@ -145,10 +145,13 @@ pytest-pep8==1.0.6
     # via -r requirements/test.txt
 pytest-pylint==0.18.0
     # via -r requirements/test.txt
-pytest-xdist==2.2.0
-    # via -r requirements/test.txt
-pytest==6.2.2
+pytest-xdist==1.34.0
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+pytest==5.4.3
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pytest-cache
     #   pytest-cov
@@ -175,6 +178,7 @@ six==1.15.0
     #   -r requirements/test.txt
     #   astroid
     #   edx-lint
+    #   pytest-xdist
 sortedcontainers==2.3.0
     # via
     #   -r requirements/test.txt
@@ -196,8 +200,11 @@ toml==0.10.2
     # via
     #   -r requirements/test.txt
     #   pylint
-    #   pytest
     #   pytest-pylint
+wcwidth==0.2.5
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 wrapt==1.12.1
     # via
     #   -r requirements/test.txt

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -5,7 +5,9 @@
 #    make upgrade
 #
 django==2.2.17
-    # via -r requirements/django.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/django.in
 pytz==2020.5
     # via django
 sqlparse==0.4.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -22,7 +22,7 @@ attrs==20.3.0
     #   pytest
 babel==2.9.0
     # via sphinx
-bleach==3.2.2
+bleach==3.2.3
     # via readme-renderer
 certifi==2020.12.5
     # via requests
@@ -36,54 +36,70 @@ click==7.1.2
     # via
     #   -r requirements/test.txt
     #   click-log
+    #   code-annotations
     #   edx-lint
-coverage==5.3.1
+code-annotations==1.0.2
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+coverage==5.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 ddt==1.4.1
     # via -r requirements/test.txt
+django==2.2.17
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   edx-lint
 docutils==0.16
     # via
     #   readme-renderer
     #   sphinx
-edx-lint==1.6
+edx-lint==3.0.2
     # via -r requirements/test.txt
 edx-sphinx-theme==1.6.1
     # via -r requirements/doc.in
-execnet==1.7.1
+execnet==1.8.0
     # via
     #   -r requirements/test.txt
     #   pytest-cache
     #   pytest-xdist
-hypothesis==6.0.2
+hypothesis==6.0.4
     # via -r requirements/test.txt
 idna==2.10
     # via requests
 imagesize==1.2.0
     # via sphinx
+iniconfig==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 isort==5.7.0
     # via
     #   -r requirements/test.txt
     #   pylint
 jinja2==2.11.2
-    # via sphinx
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
+    #   sphinx
 lazy-object-proxy==1.4.3
     # via
     #   -r requirements/test.txt
     #   astroid
 markupsafe==1.1.1
-    # via jinja2
+    # via
+    #   -r requirements/test.txt
+    #   jinja2
 mccabe==0.6.1
     # via
     #   -r requirements/test.txt
     #   pylint
 mock==4.0.3
     # via -r requirements/test.txt
-more-itertools==8.6.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 packaging==20.8
     # via
     #   -r requirements/test.txt
@@ -117,7 +133,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-django==2.3.0
+pylint-django==2.4.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -152,17 +168,12 @@ pytest-forked==1.3.0
     #   pytest-xdist
 pytest-pep8==1.0.6
     # via -r requirements/test.txt
-pytest-pylint==0.15.1
+pytest-pylint==0.18.0
+    # via -r requirements/test.txt
+pytest-xdist==2.2.0
+    # via -r requirements/test.txt
+pytest==6.2.2
     # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-pytest-xdist==1.34.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-pytest==5.3.0
-    # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pytest-cache
     #   pytest-cov
@@ -170,8 +181,19 @@ pytest==5.3.0
     #   pytest-pep8
     #   pytest-pylint
     #   pytest-xdist
+python-slugify==4.0.1
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
 pytz==2020.5
-    # via babel
+    # via
+    #   -r requirements/test.txt
+    #   babel
+    #   django
+pyyaml==5.4.1
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
 readme-renderer==28.0
     # via -r requirements/doc.in
 requests==2.25.1
@@ -183,9 +205,8 @@ six==1.15.0
     #   bleach
     #   edx-lint
     #   edx-sphinx-theme
-    #   pytest-xdist
     #   readme-renderer
-snowballstemmer==2.0.0
+snowballstemmer==2.1.0
     # via sphinx
 sortedcontainers==2.3.0
     # via
@@ -207,18 +228,26 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.4
     # via sphinx
+sqlparse==0.4.1
+    # via
+    #   -r requirements/test.txt
+    #   django
 stevedore==3.3.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   code-annotations
+text-unidecode==1.3
+    # via
+    #   -r requirements/test.txt
+    #   python-slugify
 toml==0.10.2
     # via
     #   -r requirements/test.txt
     #   pylint
-urllib3==1.26.2
-    # via requests
-wcwidth==0.2.5
-    # via
-    #   -r requirements/test.txt
     #   pytest
+    #   pytest-pylint
+urllib3==1.26.3
+    # via requests
 webencodings==0.5.1
     # via bleach
 wrapt==1.12.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -73,10 +73,6 @@ idna==2.10
     # via requests
 imagesize==1.2.0
     # via sphinx
-iniconfig==1.1.1
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 isort==5.7.0
     # via
     #   -r requirements/test.txt
@@ -100,6 +96,10 @@ mccabe==0.6.1
     #   pylint
 mock==4.0.3
     # via -r requirements/test.txt
+more-itertools==8.6.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 packaging==20.8
     # via
     #   -r requirements/test.txt
@@ -170,10 +170,13 @@ pytest-pep8==1.0.6
     # via -r requirements/test.txt
 pytest-pylint==0.18.0
     # via -r requirements/test.txt
-pytest-xdist==2.2.0
-    # via -r requirements/test.txt
-pytest==6.2.2
+pytest-xdist==1.34.0
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+pytest==5.4.3
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pytest-cache
     #   pytest-cov
@@ -205,6 +208,7 @@ six==1.15.0
     #   bleach
     #   edx-lint
     #   edx-sphinx-theme
+    #   pytest-xdist
     #   readme-renderer
 snowballstemmer==2.1.0
     # via sphinx
@@ -244,10 +248,13 @@ toml==0.10.2
     # via
     #   -r requirements/test.txt
     #   pylint
-    #   pytest
     #   pytest-pylint
 urllib3==1.26.3
     # via requests
+wcwidth==0.2.5
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 webencodings==0.5.1
     # via bleach
 wrapt==1.12.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,31 +19,43 @@ click-log==0.3.2
 click==7.1.2
     # via
     #   click-log
+    #   code-annotations
     #   edx-lint
-coverage==5.3.1
+code-annotations==1.0.2
+    # via edx-lint
+coverage==5.4
     # via
     #   -r requirements/test.in
     #   pytest-cov
 ddt==1.4.1
     # via -r requirements/test.in
-edx-lint==1.6
+django==2.2.17
+    # via
+    #   -c requirements/constraints.txt
+    #   code-annotations
+    #   edx-lint
+edx-lint==3.0.2
     # via -r requirements/test.in
-execnet==1.7.1
+execnet==1.8.0
     # via
     #   pytest-cache
     #   pytest-xdist
-hypothesis==6.0.2
+hypothesis==6.0.4
     # via -r requirements/test.in
+iniconfig==1.1.1
+    # via pytest
 isort==5.7.0
     # via pylint
+jinja2==2.11.2
+    # via code-annotations
 lazy-object-proxy==1.4.3
     # via astroid
+markupsafe==1.1.1
+    # via jinja2
 mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r requirements/test.in
-more-itertools==8.6.0
-    # via pytest
 packaging==20.8
     # via pytest
 pbr==5.5.1
@@ -62,7 +74,7 @@ pycodestyle==2.6.0
     # via -r requirements/test.in
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.3.0
+pylint-django==2.4.2
     # via edx-lint
 pylint-plugin-utils==0.6
     # via
@@ -87,17 +99,12 @@ pytest-forked==1.3.0
     # via pytest-xdist
 pytest-pep8==1.0.6
     # via -r requirements/test.in
-pytest-pylint==0.15.1
+pytest-pylint==0.18.0
+    # via -r requirements/test.in
+pytest-xdist==2.2.0
+    # via -r requirements/test.in
+pytest==6.2.2
     # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
-pytest-xdist==1.34.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
-pytest==5.3.0
-    # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.in
     #   pytest-cache
     #   pytest-cov
@@ -105,19 +112,31 @@ pytest==5.3.0
     #   pytest-pep8
     #   pytest-pylint
     #   pytest-xdist
+python-slugify==4.0.1
+    # via code-annotations
+pytz==2020.5
+    # via django
+pyyaml==5.4.1
+    # via code-annotations
 six==1.15.0
     # via
     #   -r requirements/base.txt
     #   astroid
     #   edx-lint
-    #   pytest-xdist
 sortedcontainers==2.3.0
     # via hypothesis
+sqlparse==0.4.1
+    # via django
 stevedore==3.3.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+text-unidecode==1.3
+    # via python-slugify
 toml==0.10.2
-    # via pylint
-wcwidth==0.2.5
-    # via pytest
+    # via
+    #   pylint
+    #   pytest
+    #   pytest-pylint
 wrapt==1.12.1
     # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -42,8 +42,6 @@ execnet==1.8.0
     #   pytest-xdist
 hypothesis==6.0.4
     # via -r requirements/test.in
-iniconfig==1.1.1
-    # via pytest
 isort==5.7.0
     # via pylint
 jinja2==2.11.2
@@ -56,6 +54,8 @@ mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r requirements/test.in
+more-itertools==8.6.0
+    # via pytest
 packaging==20.8
     # via pytest
 pbr==5.5.1
@@ -101,10 +101,13 @@ pytest-pep8==1.0.6
     # via -r requirements/test.in
 pytest-pylint==0.18.0
     # via -r requirements/test.in
-pytest-xdist==2.2.0
-    # via -r requirements/test.in
-pytest==6.2.2
+pytest-xdist==1.34.0
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+pytest==5.4.3
+    # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
     #   pytest-cache
     #   pytest-cov
@@ -120,9 +123,9 @@ pyyaml==5.4.1
     # via code-annotations
 six==1.15.0
     # via
-    #   -r requirements/base.txt
     #   astroid
     #   edx-lint
+    #   pytest-xdist
 sortedcontainers==2.3.0
     # via hypothesis
 sqlparse==0.4.1
@@ -136,7 +139,8 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   pylint
-    #   pytest
     #   pytest-pylint
+wcwidth==0.2.5
+    # via pytest
 wrapt==1.12.1
     # via astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -10,7 +10,7 @@ certifi==2020.12.5
     # via requests
 chardet==4.0.0
     # via requests
-coverage==5.3.1
+coverage==5.4
     # via coveralls
 coveralls==3.0.0
     # via -r requirements/travis.in
@@ -42,11 +42,11 @@ toml==0.10.2
     # via tox
 tox-battery==0.6.1
     # via -r requirements/travis.in
-tox==3.21.2
+tox==3.21.3
     # via
     #   -r requirements/travis.in
     #   tox-battery
-urllib3==1.26.2
+urllib3==1.26.3
     # via requests
 virtualenv==20.4.0
     # via tox

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.8",
     ],
     # We are including the tests because other libraries do use mixins from them.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def is_requirement(line):
 
 setup(
     name='edx-opaque-keys',
-    version='2.1.1',
+    version='2.2.0',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[


### PR DESCRIPTION
Upgrade build was failing because of Django version conflicts https://build.testeng.edx.org/job/opaque-keys-upgrade-python-requirements/88/console 
So added Django constraint, removed previous constraints which are not required now. 
Updated the PyPI build to be deployed using `Python3.8`. 
Bumped the version to `2.2.0` and updated the `CHANGELOG`.