### PR TITLE
BOM-2548: Add common constraints

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-pbr==5.5.1
+pbr==5.6.0
     # via stevedore
-pymongo==3.11.3
+pymongo==3.11.4
     # via -r requirements/base.in
 stevedore==3.3.0
     # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,8 +8,8 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# stay on LTS release
-Django<2.3
+# This file contains all common constraints for edx-repos
+-c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
 # pytest>=5.6.0 fails to fetch the tests and hence all the tests fail
 pytest<5.6.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,17 +16,17 @@ appdirs==1.4.4
     # via
     #   -r requirements/travis.txt
     #   virtualenv
-astroid==2.5.2
+astroid==2.5.6
     # via
     #   -r requirements/doc.txt
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -r requirements/doc.txt
     #   hypothesis
     #   pytest
-babel==2.9.0
+babel==2.9.1
     # via
     #   -r requirements/doc.txt
     #   sphinx
@@ -50,6 +50,7 @@ click-log==0.3.2
     #   edx-lint
 click==7.1.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.txt
     #   -r requirements/pip-tools.txt
     #   click-log
@@ -60,7 +61,7 @@ code-annotations==1.1.1
     # via
     #   -r requirements/doc.txt
     #   edx-lint
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/doc.txt
     #   -r requirements/travis.txt
@@ -74,9 +75,9 @@ distlib==0.3.1
     # via
     #   -r requirements/travis.txt
     #   virtualenv
-django==2.2.19
+django==2.2.23
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.txt
     #   code-annotations
     #   edx-lint
@@ -86,12 +87,13 @@ docopt==0.6.2
     #   coveralls
 docutils==0.16
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.txt
     #   readme-renderer
     #   sphinx
 edx-lint==5.0.0
     # via -r requirements/doc.txt
-edx-sphinx-theme==2.0.0
+edx-sphinx-theme==2.1.0
     # via -r requirements/doc.txt
 execnet==1.8.0
     # via
@@ -103,7 +105,7 @@ filelock==3.0.12
     #   -r requirements/travis.txt
     #   tox
     #   virtualenv
-hypothesis==6.8.3
+hypothesis==6.13.0
     # via -r requirements/doc.txt
 idna==2.10
     # via
@@ -120,6 +122,7 @@ isort==5.8.0
     #   pylint
 jinja2==2.11.3
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.txt
     #   code-annotations
     #   sphinx
@@ -129,8 +132,10 @@ lazy-object-proxy==1.6.0
     #   astroid
 markupsafe==1.1.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.txt
     #   jinja2
+    #   sphinx
 mccabe==0.6.1
     # via
     #   -r requirements/doc.txt
@@ -149,7 +154,7 @@ packaging==20.9
     #   pytest
     #   sphinx
     #   tox
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/doc.txt
     #   stevedore
@@ -161,7 +166,7 @@ pep8==1.7.1
     # via
     #   -r requirements/doc.txt
     #   pytest-pep8
-pip-tools==6.0.1
+pip-tools==6.1.0
     # via -r requirements/pip-tools.txt
 pluggy==0.13.1
     # via
@@ -178,7 +183,7 @@ py==1.10.0
     #   tox
 pycodestyle==2.7.0
     # via -r requirements/doc.txt
-pygments==2.8.1
+pygments==2.9.0
     # via
     #   -r requirements/doc.txt
     #   readme-renderer
@@ -187,7 +192,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/doc.txt
     #   edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.4
     # via
     #   -r requirements/doc.txt
     #   edx-lint
@@ -196,7 +201,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/doc.txt
     #   pylint-celery
     #   pylint-django
-pylint==2.7.4
+pylint==2.8.2
     # via
     #   -r requirements/doc.txt
     #   edx-lint
@@ -204,7 +209,7 @@ pylint==2.7.4
     #   pylint-django
     #   pylint-plugin-utils
     #   pytest-pylint
-pymongo==3.11.3
+pymongo==3.11.4
     # via -r requirements/doc.txt
 pyparsing==2.4.7
     # via
@@ -215,7 +220,7 @@ pytest-cache==1.0
     # via
     #   -r requirements/doc.txt
     #   pytest-pep8
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/doc.txt
 pytest-forked==1.3.0
     # via
@@ -239,7 +244,7 @@ pytest==5.4.3
     #   pytest-pep8
     #   pytest-pylint
     #   pytest-xdist
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via
     #   -r requirements/doc.txt
     #   code-annotations
@@ -260,7 +265,7 @@ requests==2.25.1
     #   -r requirements/travis.txt
     #   coveralls
     #   sphinx
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/travis.txt
@@ -275,11 +280,11 @@ snowballstemmer==2.1.0
     # via
     #   -r requirements/doc.txt
     #   sphinx
-sortedcontainers==2.3.0
+sortedcontainers==2.4.0
     # via
     #   -r requirements/doc.txt
     #   hypothesis
-sphinx==3.5.3
+sphinx==4.0.1
     # via
     #   -r requirements/doc.txt
     #   edx-sphinx-theme
@@ -324,13 +329,14 @@ toml==0.10.2
     #   -r requirements/doc.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/travis.txt
+    #   coverage
     #   pep517
     #   pylint
     #   pytest-pylint
     #   tox
 tox-battery==0.6.1
     # via -r requirements/travis.txt
-tox==3.23.0
+tox==3.23.1
     # via
     #   -r requirements/travis.txt
     #   tox-battery
@@ -339,7 +345,7 @@ urllib3==1.26.4
     #   -r requirements/doc.txt
     #   -r requirements/travis.txt
     #   requests
-virtualenv==20.4.3
+virtualenv==20.4.6
     # via
     #   -r requirements/travis.txt
     #   tox

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -8,12 +8,12 @@ apipkg==1.5
     # via
     #   -r requirements/test.txt
     #   execnet
-astroid==2.5.2
+astroid==2.5.6
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -r requirements/test.txt
     #   hypothesis
@@ -24,6 +24,7 @@ click-log==0.3.2
     #   edx-lint
 click==7.1.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   click-log
     #   code-annotations
@@ -32,14 +33,14 @@ code-annotations==1.1.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 ddt==1.4.2
     # via -r requirements/test.txt
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/django.txt
     #   -r requirements/test.txt
     #   code-annotations
@@ -51,7 +52,7 @@ execnet==1.8.0
     #   -r requirements/test.txt
     #   pytest-cache
     #   pytest-xdist
-hypothesis==6.8.3
+hypothesis==6.13.0
     # via -r requirements/test.txt
 isort==5.8.0
     # via
@@ -59,6 +60,7 @@ isort==5.8.0
     #   pylint
 jinja2==2.11.3
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
 lazy-object-proxy==1.6.0
@@ -67,6 +69,7 @@ lazy-object-proxy==1.6.0
     #   astroid
 markupsafe==1.1.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   jinja2
 mccabe==0.6.1
@@ -83,7 +86,7 @@ packaging==20.9
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -106,7 +109,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -115,7 +118,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pylint==2.7.4
+pylint==2.8.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -123,7 +126,7 @@ pylint==2.7.4
     #   pylint-django
     #   pylint-plugin-utils
     #   pytest-pylint
-pymongo==3.11.3
+pymongo==3.11.4
     # via -r requirements/test.txt
 pyparsing==2.4.7
     # via
@@ -133,9 +136,9 @@ pytest-cache==1.0
     # via
     #   -r requirements/test.txt
     #   pytest-pep8
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/test.txt
-pytest-django==4.1.0
+pytest-django==4.3.0
     # via -r requirements/django-test.in
 pytest-forked==1.3.0
     # via
@@ -160,7 +163,7 @@ pytest==5.4.3
     #   pytest-pep8
     #   pytest-pylint
     #   pytest-xdist
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -173,12 +176,12 @@ pyyaml==5.4.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
     #   pytest-xdist
-sortedcontainers==2.3.0
+sortedcontainers==2.4.0
     # via
     #   -r requirements/test.txt
     #   hypothesis
@@ -198,6 +201,7 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/test.txt
+    #   coverage
     #   pylint
     #   pytest-pylint
 wcwidth==0.2.5

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-django==2.2.19
+django==2.2.23
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/django.in
 pytz==2021.1
     # via django

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,17 +10,17 @@ apipkg==1.5
     # via
     #   -r requirements/test.txt
     #   execnet
-astroid==2.5.2
+astroid==2.5.6
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -r requirements/test.txt
     #   hypothesis
     #   pytest
-babel==2.9.0
+babel==2.9.1
     # via sphinx
 bleach==3.3.0
     # via readme-renderer
@@ -34,6 +34,7 @@ click-log==0.3.2
     #   edx-lint
 click==7.1.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   click-log
     #   code-annotations
@@ -42,32 +43,33 @@ code-annotations==1.1.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 ddt==1.4.2
     # via -r requirements/test.txt
-django==2.2.19
+django==2.2.23
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-lint
 docutils==0.16
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   readme-renderer
     #   sphinx
 edx-lint==5.0.0
     # via -r requirements/test.txt
-edx-sphinx-theme==2.0.0
+edx-sphinx-theme==2.1.0
     # via -r requirements/doc.in
 execnet==1.8.0
     # via
     #   -r requirements/test.txt
     #   pytest-cache
     #   pytest-xdist
-hypothesis==6.8.3
+hypothesis==6.13.0
     # via -r requirements/test.txt
 idna==2.10
     # via requests
@@ -79,6 +81,7 @@ isort==5.8.0
     #   pylint
 jinja2==2.11.3
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinx
@@ -88,8 +91,10 @@ lazy-object-proxy==1.6.0
     #   astroid
 markupsafe==1.1.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   jinja2
+    #   sphinx
 mccabe==0.6.1
     # via
     #   -r requirements/test.txt
@@ -106,7 +111,7 @@ packaging==20.9
     #   bleach
     #   pytest
     #   sphinx
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -125,7 +130,7 @@ py==1.10.0
     #   pytest-forked
 pycodestyle==2.7.0
     # via -r requirements/test.txt
-pygments==2.8.1
+pygments==2.9.0
     # via
     #   readme-renderer
     #   sphinx
@@ -133,7 +138,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -142,7 +147,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pylint==2.7.4
+pylint==2.8.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -150,7 +155,7 @@ pylint==2.7.4
     #   pylint-django
     #   pylint-plugin-utils
     #   pytest-pylint
-pymongo==3.11.3
+pymongo==3.11.4
     # via -r requirements/test.txt
 pyparsing==2.4.7
     # via
@@ -160,7 +165,7 @@ pytest-cache==1.0
     # via
     #   -r requirements/test.txt
     #   pytest-pep8
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/test.txt
 pytest-forked==1.3.0
     # via
@@ -184,7 +189,7 @@ pytest==5.4.3
     #   pytest-pep8
     #   pytest-pylint
     #   pytest-xdist
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -201,7 +206,7 @@ readme-renderer==29.0
     # via -r requirements/doc.in
 requests==2.25.1
     # via sphinx
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/test.txt
     #   bleach
@@ -211,11 +216,11 @@ six==1.15.0
     #   readme-renderer
 snowballstemmer==2.1.0
     # via sphinx
-sortedcontainers==2.3.0
+sortedcontainers==2.4.0
     # via
     #   -r requirements/test.txt
     #   hypothesis
-sphinx==3.5.3
+sphinx==4.0.1
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -246,6 +251,7 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/test.txt
+    #   coverage
     #   pylint
     #   pytest-pylint
 urllib3==1.26.4

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,10 +5,12 @@
 #    make upgrade
 #
 click==7.1.2
-    # via pip-tools
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   pip-tools
 pep517==0.10.0
     # via pip-tools
-pip-tools==6.0.1
+pip-tools==6.1.0
     # via -r requirements/pip-tools.in
 toml==0.10.2
     # via pep517

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,11 +6,11 @@
 #
 apipkg==1.5
     # via execnet
-astroid==2.5.2
+astroid==2.5.6
     # via
     #   pylint
     #   pylint-celery
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   hypothesis
     #   pytest
@@ -18,20 +18,21 @@ click-log==0.3.2
     # via edx-lint
 click==7.1.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint
 code-annotations==1.1.1
     # via edx-lint
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
 ddt==1.4.2
     # via -r requirements/test.in
-django==2.2.19
+django==2.2.23
     # via
-    #   -c requirements/constraints.txt
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   code-annotations
     #   edx-lint
 edx-lint==5.0.0
@@ -40,16 +41,20 @@ execnet==1.8.0
     # via
     #   pytest-cache
     #   pytest-xdist
-hypothesis==6.8.3
+hypothesis==6.13.0
     # via -r requirements/test.in
 isort==5.8.0
     # via pylint
 jinja2==2.11.3
-    # via code-annotations
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   code-annotations
 lazy-object-proxy==1.6.0
     # via astroid
 markupsafe==1.1.1
-    # via jinja2
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   jinja2
 mccabe==0.6.1
     # via pylint
 mock==4.0.3
@@ -58,7 +63,7 @@ more-itertools==8.7.0
     # via pytest
 packaging==20.9
     # via pytest
-pbr==5.5.1
+pbr==5.6.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -74,26 +79,26 @@ pycodestyle==2.7.0
     # via -r requirements/test.in
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.4
     # via edx-lint
 pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pylint==2.7.4
+pylint==2.8.2
     # via
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
     #   pytest-pylint
-pymongo==3.11.3
+pymongo==3.11.4
     # via -r requirements/base.txt
 pyparsing==2.4.7
     # via packaging
 pytest-cache==1.0
     # via pytest-pep8
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/test.in
 pytest-forked==1.3.0
     # via pytest-xdist
@@ -115,17 +120,17 @@ pytest==5.4.3
     #   pytest-pep8
     #   pytest-pylint
     #   pytest-xdist
-python-slugify==4.0.1
+python-slugify==5.0.2
     # via code-annotations
 pytz==2021.1
     # via django
 pyyaml==5.4.1
     # via code-annotations
-six==1.15.0
+six==1.16.0
     # via
     #   edx-lint
     #   pytest-xdist
-sortedcontainers==2.3.0
+sortedcontainers==2.4.0
     # via hypothesis
 sqlparse==0.4.1
     # via django
@@ -137,6 +142,7 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via
+    #   coverage
     #   pylint
     #   pytest-pylint
 wcwidth==0.2.5

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -34,7 +34,7 @@ pyparsing==2.4.7
     # via packaging
 requests==2.25.1
     # via coveralls
-six==1.15.0
+six==1.16.0
     # via
     #   tox
     #   virtualenv
@@ -42,11 +42,11 @@ toml==0.10.2
     # via tox
 tox-battery==0.6.1
     # via -r requirements/travis.in
-tox==3.23.0
+tox==3.23.1
     # via
     #   -r requirements/travis.in
     #   tox-battery
 urllib3==1.26.4
     # via requests
-virtualenv==20.4.3
+virtualenv==20.4.6
     # via tox


### PR DESCRIPTION
**Issue:** [BOM-2548](https://openedx.atlassian.net/browse/BOM-2548)

### Description
- The repo didn't have common constraints in it. Adding common constraints resolved the upgrade conflict which was causing the [requirements upgrade job failure](https://build.testeng.edx.org/job/opaque-keys-upgrade-python-requirements/104/console).