### PR TITLE
chore: Bump version to 2.2.1 after upgrading dependencies.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+# 2.2.1
+
+* Upgraded dependencies
+
 # 2.2.0
 
 * Dropped support for Python3.5

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def is_requirement(line):
 
 setup(
     name='edx-opaque-keys',
-    version='2.2.0',
+    version='2.2.1',
     author='edX',
     url='https://github.com/edx/opaque-keys',
     classifiers=[


### PR DESCRIPTION
All Python dependencies were upgraded in this PR: https://github.com/edx/opaque-keys/pull/182

This PR bumps the patch version of the package.