### PR TITLE
feat: CourseKeyField can now be optionally case-sensitive, has default max_length [FC-0117]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ __pycache__/
 codekit-config.json
 .pycharm_helpers/
 
+# Virtual environment
+.venv
+
 # Distribution / packaging
 .Python
 env/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+# 3.1.0
+
+* The Django OpaqueKeyField subclasses like CourseKeyField now specify a default
+  max_length of 255 characters.
+* The Django OpaqueKeyField subclasses now are case-insensitive on SQLite by
+  default, to match the behavior they had on MySQL.
+* The Django OpaqueKeyField subclasses can now be made case-sensitive by passing
+  the new case_sensitive=True parameter (recommended).
+
 # 3.0.0
 
 * Breaking: LibraryItemKey is replaced by CollectionKey and ContainerKey

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 # 3.1.0
 
 * The Django OpaqueKeyField subclasses like CourseKeyField now specify a default
-  max_length of 255 characters.
+  max_length of 255 characters (previously, no default was specified).
 * The Django OpaqueKeyField subclasses now are case-insensitive on SQLite by
   default, to match the behavior they had on MySQL.
 * The Django OpaqueKeyField subclasses can now be made case-sensitive by passing

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -14,7 +14,7 @@ from typing import Self
 
 from stevedore.enabled import EnabledExtensionManager
 
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 
 class InvalidKeyError(Exception):

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -96,7 +96,7 @@ class OpaqueKeyField(CreatorMixin, CharField):
 
     def __init__(self, *args, **kwargs):
         if self.KEY_CLASS is None:
-            raise ValueError('Must specify KEY_CLASS in OpaqueKeyField subclasses')
+            raise ValueError('Must specify KEY_CLASS in OpaqueKeyField subclasses')  # pragma: no cover
         kwargs.setdefault("max_length", 255)  # Default max length for all opaque key fields
         self.case_sensitive = kwargs.pop("case_sensitive", False)  # see self.db_parameters() for details
         super().__init__(*args, **kwargs)
@@ -179,7 +179,7 @@ class OpaqueKeyField(CreatorMixin, CharField):
 
         if connection.vendor == "sqlite":
             db_params["collation"] = "BINARY" if self.case_sensitive else "NOCASE"
-        elif connection.vendor == "mysql":
+        elif connection.vendor == "mysql":  # pragma: no cover
             db_params["collation"] = "utf8mb4_bin" if self.case_sensitive else "utf8mb4_unicode_ci"
             # We're using utf8mb4_unicode_ci to keep MariaDB compatibility, since their collation support diverges after
             # this. MySQL is now on utf8mb4_0900_ai_ci based on Unicode 9, while MariaDB has uca1400_ai_ci (Unicode 14).

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -183,6 +183,11 @@ class OpaqueKeyField(CreatorMixin, CharField):
             db_params["collation"] = "utf8mb4_bin" if self.case_sensitive else "utf8mb4_unicode_ci"
             # We're using utf8mb4_unicode_ci to keep MariaDB compatibility, since their collation support diverges after
             # this. MySQL is now on utf8mb4_0900_ai_ci based on Unicode 9, while MariaDB has uca1400_ai_ci (Unicode 14).
+        elif connection.vendor == "postgresql":  # pragma: no cover
+            pass  # PostgreSQL only provides case-sensitive collations by default. To create a case-insensitive column,
+                  # we'd first need to use a migration to create a custom case-insensitive collation, but we don't use
+                  # migrations for this opaque-keys library. Anyhow, using case-sensitivity across the board is less
+                  # likely to cause bugs than the opposite.
 
         return db_params
 
@@ -224,6 +229,10 @@ class LearningContextKeyField(OpaqueKeyField):
     CourseKeyField instead, but if you are writing something more generic that
     could apply to any learning context (libraries, etc.), use this instead of
     CourseKeyField.
+
+    It is highly recommended to specify `case_sensitive=True`, because we
+    generally want the performance, exactness, and consistency of case-sensitive
+    values, but the default behavior is case-insensitive (except on PostgreSQL).
     """
     description = "A LearningContextKey object, saved to the DB in the form of a string"
     KEY_CLASS = LearningContextKey
@@ -238,6 +247,10 @@ class LearningContextKeyField(OpaqueKeyField):
 class CourseKeyField(OpaqueKeyField):
     """
     A django Field that stores a CourseKey object as a string.
+
+    It is highly recommended to specify `case_sensitive=True`, because we
+    generally want the performance, exactness, and consistency of case-sensitive
+    values, but the default behavior is case-insensitive (except on PostgreSQL).
     """
     description = "A CourseKey object, saved to the DB in the form of a string"
     KEY_CLASS = CourseKey
@@ -249,6 +262,10 @@ class CourseKeyField(OpaqueKeyField):
 class UsageKeyField(OpaqueKeyField):
     """
     A django Field that stores a UsageKey object as a string.
+
+    It is highly recommended to specify `case_sensitive=True`, because we
+    generally want the performance, exactness, and consistency of case-sensitive
+    values, but the default behavior is case-insensitive (except on PostgreSQL).
     """
     description = "A Location object, saved to the DB in the form of a string"
     KEY_CLASS = UsageKey
@@ -260,6 +277,10 @@ class UsageKeyField(OpaqueKeyField):
 class ContainerKeyField(OpaqueKeyField):
     """
     A django Field that stores a ContainerKey object as a string.
+
+    It is highly recommended to specify `case_sensitive=True`, because we
+    generally want the performance, exactness, and consistency of case-sensitive
+    values, but the default behavior is case-insensitive (except on PostgreSQL).
     """
     description = "A Location object, saved to the DB in the form of a string"
     KEY_CLASS = ContainerKey
@@ -271,6 +292,10 @@ class ContainerKeyField(OpaqueKeyField):
 class CollectionKeyField(OpaqueKeyField):
     """
     A django Field that stores a CollectionKey object as a string.
+
+    It is highly recommended to specify `case_sensitive=True`, because we
+    generally want the performance, exactness, and consistency of case-sensitive
+    values, but the default behavior is case-insensitive (except on PostgreSQL).
     """
     description = "A Location object, saved to the DB in the form of a string"
     KEY_CLASS = CollectionKey
@@ -282,6 +307,10 @@ class CollectionKeyField(OpaqueKeyField):
 class LocationKeyField(UsageKeyField):
     """
     A django Field that stores a UsageKey object as a string.
+
+    It is highly recommended to specify `case_sensitive=True`, because we
+    generally want the performance, exactness, and consistency of case-sensitive
+    values, but the default behavior is case-insensitive (except on PostgreSQL).
     """
 
     def __init__(self, *args, **kwargs):
@@ -292,6 +321,10 @@ class LocationKeyField(UsageKeyField):
 class BlockTypeKeyField(OpaqueKeyField):
     """
     A django Field that stores a BlockTypeKey object as a string.
+
+    It is highly recommended to specify `case_sensitive=True`, because we
+    generally want the performance, exactness, and consistency of case-sensitive
+    values, but the default behavior is case-insensitive (except on PostgreSQL).
     """
     description = "A BlockTypeKey object, saved to the DB in the form of a string."
     KEY_CLASS = BlockTypeKey

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -184,10 +184,11 @@ class OpaqueKeyField(CreatorMixin, CharField):
             # We're using utf8mb4_unicode_ci to keep MariaDB compatibility, since their collation support diverges after
             # this. MySQL is now on utf8mb4_0900_ai_ci based on Unicode 9, while MariaDB has uca1400_ai_ci (Unicode 14).
         elif connection.vendor == "postgresql":  # pragma: no cover
-            pass  # PostgreSQL only provides case-sensitive collations by default. To create a case-insensitive column,
-                  # we'd first need to use a migration to create a custom case-insensitive collation, but we don't use
-                  # migrations for this opaque-keys library. Anyhow, using case-sensitivity across the board is less
-                  # likely to cause bugs than the opposite.
+            # PostgreSQL only provides case-sensitive collations by default. To create a case-insensitive column,
+            # we'd first need to use a migration to create a custom case-insensitive collation, but we don't use
+            # migrations for this opaque-keys library. Anyhow, using case-sensitivity across the board is less
+            # likely to cause bugs than the opposite.
+            pass
 
         return db_params
 

--- a/opaque_keys/edx/django/tests/models.py
+++ b/opaque_keys/edx/django/tests/models.py
@@ -66,8 +66,9 @@ class ComplexModel(Model):
     """A Django Model for testing Course/Usage/Location/BlockType Key fields."""
 
     id = CharField(primary_key=True, max_length=255)  # pylint: disable=invalid-name
-    course_key = CourseKeyField(max_length=255, validators=[is_edx])
-    block_type_key = BlockTypeKeyField(max_length=255, blank=True)
-    usage_key = UsageKeyField(max_length=255, blank=False)
-    collection_key = CollectionKeyField(max_length=255, blank=False)
-    container_key = ContainerKeyField(max_length=255, blank=False)
+    course_key = CourseKeyField(validators=[is_edx])
+    course_key_cs = CourseKeyField(case_sensitive=True, max_length=100)
+    block_type_key = BlockTypeKeyField(blank=True)
+    usage_key = UsageKeyField(blank=False)
+    collection_key = CollectionKeyField(blank=False)
+    container_key = ContainerKeyField(blank=False)


### PR DESCRIPTION
Our `CourseKeyField` and other opaque key fields by default are case-sensitive on SQLite but case-_insensitive_ on MySQL. This opposite behavior can result in surprising bugs if you only test on SQLite.

This PR:
* Changes `CourseKeyField` so that it's case-insensitive by default on both SQLite and MySQL, matching the previous MySQL default behavior
   - This is technically a breaking change for SQLite, but not a breaking change for MySQL users, which is every production use case.
   - This will not result in any additional/changed migrations. As a result, it does not apply retroactively on any long-running SQLite databases; I don't think we have any though.
   - I suspect this _may_ trigger a change in collation of some columns if you create a future migration that modifies some other aspect of these columns, such as `blank` or `max_length` ? e.g. if your database was still using `utf8_general_ci` by default and you make some unrelated change that results in an `ALTER TABLE` migration that updates one of these columns, it may change the collation to `utf8mb4_unicode_ci`. Since opaque keys are restricted to mostly ASCII characters anyways, I don't think this will matter, if it even happens. (?)
* Allows apps to opt-in to case-sensitivity with `CourseKeyField(case_sensitive=True)`, which is highly recommended, and will apply to both SQLite and MySQL consistently.
* Specifies a default value for `max_length` so you don't have to pointlessly specify the same max length over and over every time you store an opaque key field.
* Does not yet support PostgreSQL - the `case_sensitive=True` argument will be ignored. But I think that PostgreSQL will always be case sensitive by default, and doesn't ship with any case-insensitive collations, although you can manually create them. [(ref)](https://stackoverflow.com/a/59101567/1057326)