### PR TITLE
feat!: rename LibraryCollectionLocator.collection_id to collection_code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+# 4.0.0
+
+* Breaking: ``LibraryCollectionLocator.collection_id`` is renamed to ``LibraryCollectionLocator.collection_code``.
+  There is a readonly ``collection_id`` property for backwards compatibility, but calls to the constructor
+  which use the ``collection_id=`` kwarg must be updated to ``collection_code=``.
+
 # 3.1.0
 
 * The Django OpaqueKeyField subclasses like CourseKeyField now specify a default

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -14,7 +14,7 @@ from typing import Self
 
 from stevedore.enabled import EnabledExtensionManager
 
-__version__ = '3.1.0'
+__version__ = '4.0.0'
 
 
 class InvalidKeyError(Exception):

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -1625,30 +1625,30 @@ class LibraryUsageLocatorV2(CheckFieldMixin, UsageKeyV2):
 class LibraryCollectionLocator(CheckFieldMixin, CollectionKey):
     """
     When serialized, these keys look like:
-        lib-collection:org:lib:collection-id
+        lib-collection:{org_code}:{library_code}:{collection_code}
     """
     CANONICAL_NAMESPACE = 'lib-collection'
-    KEY_FIELDS = ('lib_key', 'collection_id')
+    KEY_FIELDS = ('lib_key', 'collection_code')
     lib_key: LibraryLocatorV2
-    collection_id: str
+    collection_code: str
 
     __slots__ = KEY_FIELDS
     CHECKED_INIT = False
 
     # Allow collection IDs to contian unicode characters
-    COLLECTION_ID_REGEXP = re.compile(r'^[\w\-.]+$', flags=re.UNICODE)
+    COLLECTION_CODE_REGEXP = re.compile(r'^[\w\-.]+$', flags=re.UNICODE)
 
-    def __init__(self, lib_key: LibraryLocatorV2, collection_id: str):
+    def __init__(self, lib_key: LibraryLocatorV2, collection_code: str):
         """
         Construct a CollectionLocator
         """
         if not isinstance(lib_key, LibraryLocatorV2):
             raise TypeError("lib_key must be a LibraryLocatorV2")
 
-        self._check_key_string_field("collection_id", collection_id, regexp=self.COLLECTION_ID_REGEXP)
+        self._check_key_string_field("collection_code", collection_code, regexp=self.COLLECTION_CODE_REGEXP)
         super().__init__(
             lib_key=lib_key,
-            collection_id=collection_id,
+            collection_code=collection_code,
         )
 
     @property
@@ -1657,6 +1657,13 @@ class LibraryCollectionLocator(CheckFieldMixin, CollectionKey):
         The organization that this Collection belongs to.
         """
         return self.lib_key.org
+
+    @property
+    def collection_id(self) -> str:
+        """
+        Backcompat alias for collection_code
+        """
+        return self.collection_code
 
     def _to_string(self) -> str:
         """
@@ -1670,9 +1677,9 @@ class LibraryCollectionLocator(CheckFieldMixin, CollectionKey):
         Instantiate this key from a serialized string
         """
         try:
-            (org, lib_slug, collection_id) = serialized.split(':')
-            lib_key = LibraryLocatorV2(org, lib_slug)
-            return cls(lib_key, collection_id)
+            (org, library_code, collection_code) = serialized.split(':')
+            lib_key = LibraryLocatorV2(org, library_code)
+            return cls(lib_key, collection_code)
         except (ValueError, TypeError) as error:
             raise InvalidKeyError(cls, serialized) from error
 

--- a/opaque_keys/edx/tests/test_collection_locators.py
+++ b/opaque_keys/edx/tests/test_collection_locators.py
@@ -31,11 +31,11 @@ class TestLibraryCollectionLocator(LocatorBaseTest):
         lib = 'LibraryX'
         code = 'test-problem-bank'
         lib_key = LibraryLocatorV2(org=org, slug=lib)
-        coll_key = LibraryCollectionLocator(lib_key=lib_key, collection_id=code)
+        coll_key = LibraryCollectionLocator(lib_key=lib_key, collection_code=code)
         lib_key = coll_key.lib_key
         assert str(coll_key) == "lib-collection:TestX:LibraryX:test-problem-bank"
         assert coll_key.org == org
-        assert coll_key.collection_id == code
+        assert coll_key.collection_code == code
         assert lib_key.org == org
         assert lib_key.slug == lib
         assert isinstance(coll_key, CollectionKey)
@@ -44,9 +44,9 @@ class TestLibraryCollectionLocator(LocatorBaseTest):
         lib_key = LibraryLocatorV2(org="TestX", slug="lib1")
 
         with self.assertRaises(ValueError):
-            LibraryCollectionLocator(lib_key=lib_key, collection_id='usage-!@#{$%^&*}')
+            LibraryCollectionLocator(lib_key=lib_key, collection_code='usage-!@#{$%^&*}')
         with self.assertRaises(TypeError):
-            LibraryCollectionLocator(lib_key=None, collection_id='usage')
+            LibraryCollectionLocator(lib_key=None, collection_code='usage')
 
     def test_coll_key_from_string(self):
         org = 'TestX'
@@ -57,7 +57,7 @@ class TestLibraryCollectionLocator(LocatorBaseTest):
         assert coll_key == CollectionKey.from_string(str_key)
         assert str(coll_key) == str_key
         assert coll_key.org == org
-        assert coll_key.collection_id == code
+        assert coll_key.collection_code == code
         lib_key = coll_key.lib_key
         assert isinstance(lib_key, LibraryLocatorV2)
         assert lib_key.org == org


### PR DESCRIPTION
BREAKING CHANGE: `LibraryCollectionLocator.collection_id` is renamed to `LibraryCollectionLocator.collection_code`.  There is a readonly `collection_id`` property for backwards compatibility, but calls to the constructor which use the `collection_id=` kwarg must be updated to `collection_code=`.

Part of: https://github.com/openedx/openedx-core/issues/322

Related openedx-core PR: https://github.com/openedx/openedx-core/pull/504
Related openedx-platform PR: https://github.com/openedx/openedx-platform/pull/38214